### PR TITLE
Topologicalsort

### DIFF
--- a/tests/Fhaculty/Graph/Algorithm/TopologicalSortTest.php
+++ b/tests/Fhaculty/Graph/Algorithm/TopologicalSortTest.php
@@ -52,6 +52,85 @@ class TopologicalSortTest extends TestCase
     }
 
     /**
+     * We test a more complex graph.
+     *
+     * A -> B -> C
+     * P -> Q
+     * B -> Q
+     * C -> P
+     *
+     * should result into
+     *
+     * A -> B -> C
+     *              P -> Q
+     */
+    public function testGraphComplexInOrder() {
+        $graph = new Graph();
+        $graph->createVertex("A")->createEdgeTo($graph->createVertex("B"));
+
+        $alg = new TopologicalSort($graph);
+
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B'), $tsl);
+
+        $graph->getVertex("B")->createEdgeTo($graph->createVertex("C"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C'), $tsl);
+
+        $graph->createVertex("P")->createEdgeTo($graph->createVertex("Q"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C', 'P', 'Q'), $tsl);
+
+        $graph->getVertex("B")->createEdgeTo($graph->getVertex("Q"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C', 'P', 'Q'), $tsl, 'Added B -> Q');
+
+        $graph->getVertex("C")->createEdgeTo($graph->getVertex("P"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C', 'P', 'Q'), $tsl, "Complete Graph");
+    }
+
+    /**
+     * We test a more complex graph.
+     *
+     * A -> B -> C
+     * Q -> B
+     * A -> P
+     *
+     * should result into a TSL
+     *
+     * A ->         B -> C
+     *      P -> Q
+     */
+    public function testGraphComplexOutOfOrder() {
+        $graph = new Graph();
+        $graph->createVertex("A")->createEdgeTo($graph->createVertex("B"));
+
+        $alg = new TopologicalSort($graph);
+
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B'), $tsl);
+
+        $graph->getVertex("B")->createEdgeTo($graph->createVertex("C"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C'), $tsl);
+
+        $graph->createVertex("P")->createEdgeTo($graph->createVertex("Q"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'B', 'C', 'P', 'Q'), $tsl);
+
+        $graph->getVertex("Q")->createEdgeTo($graph->getVertex("B"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'P', 'Q', 'B', 'C'), $tsl, 'Added Q -> B');
+
+        $graph->getVertex("A")->createEdgeTo($graph->getVertex("P"));
+        $tsl = array_keys($alg->getVertices());
+        $this->assertSame(array('A', 'P', 'Q', 'B', 'C'), $tsl, 'Complete Graph');
+    }
+
+    /**
+     * 1 - 2 : undirected
+     *
      * @expectedException UnexpectedValueException
      */
     public function testFailUndirected()


### PR DESCRIPTION
I've added some more tests. My point of view is tests should help new developers to understand more so I used letters and added more documentation.

I'm not sure why the Algorithm returns Vertices instead of Ids. Is there a reason for this?

The new tests are explicitly written for the
"
the topologic sorting may be non-unique depending on your edges. this
algorithm tries to keep the order of vertices as added to the graph in
this case.
"
which feels 'wrong' as we should not rely on the order.

What do you think?
