### PR TITLE
Composer install for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ language: php
 php:
   - 5.4
   - 5.3
+before_script:
+  - composer install


### PR DESCRIPTION
Fixed the error at Travis:

```
ERROR: composer autoloader not found, run "composer install" 
or see README for instructions
```

Reference: https://travis-ci.org/clue/graph/jobs/5226603

Surprised also to find that phpunit still green lights it.
