### PR TITLE
Infinite loop fix caused by the order vertices are defined

### DIFF
--- a/lib/Fhaculty/Graph/Algorithm/ShortestPath/Base.php
+++ b/lib/Fhaculty/Graph/Algorithm/ShortestPath/Base.php
@@ -94,12 +94,13 @@ abstract class Base extends BaseVertex
         do {
             $pre = NULL;
             // check all edges to search for edge that points TO current vertex
-            foreach ($edges as $edge) {
+            foreach ($edges as $i => $edge) {
                 try {
                     // get start point of this edge (fails if current vertex is not its end point)
                     $pre = $edge->getVertexFromTo($currentVertex);
                     $path []= $edge;
                     $currentVertex = $pre;
+                    unset($edges[$i]);
                     break;
                 } catch (InvalidArgumentException $ignore) {
                 } // ignore: this edge does not point TO current vertex

--- a/tests/Fhaculty/Graph/Algorithm/ShortestPath/BaseShortestPathTest.php
+++ b/tests/Fhaculty/Graph/Algorithm/ShortestPath/BaseShortestPathTest.php
@@ -140,6 +140,37 @@ abstract class BaseShortestPathTest extends TestCase
         $this->assertEquals(array(2), $alg->getVerticesId());
     }
 
+    public function testVertexCreationOrder()
+    {
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+        $v5 = $graph->createVertex(5);
+        $v6 = $graph->createVertex(6);
+
+        $v1->createEdge($v2)->setWeight(4);
+        $v2->createEdge($v5)->setWeight(4);
+        $v5->createEdge($v6)->setWeight(4);
+
+        $alg = $this->createAlg($v1);
+        $distance1 = $alg->getDistance($v6);
+
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+        $v6 = $graph->createVertex(6);
+        $v5 = $graph->createVertex(5);
+
+        $v1->createEdge($v2)->setWeight(4);
+        $v2->createEdge($v5)->setWeight(4);
+        $v5->createEdge($v6)->setWeight(4);
+
+        $alg = $this->createAlg($v1);
+        $distance2 = $alg->getDistance($v6);
+
+        $this->assertSame($distance1, $distance2);
+    }
+
     protected function getExpectedWeight($edges)
     {
         $sum = 0;


### PR DESCRIPTION
This fixes issue #66

The problem is that in the second case the `Fhaculty\Graph\Algorithm\ShortestPath\Base::getEdgesToInternal()` method receives edges in order that causes an infinite loop.

In the first case edges are:

```
1 -- 2
2 -- 5
5 -- 6
```

In the second case:

```
1 -- 2
5 -- 6
2 -- 5
```

The end vertex is `6`. The problem is that the loop in the second case iterates over the array of edges and finds the second one suitable (that's OK). The current vertex becomes `5`. The loop breakes and starts from the beginning. And again the second one is suitable (that's not OK). That's why it creates and infinite sequence of vertices `6-5-6-5-6-5-6-5-...`.

Possible solutions are IMO two:
1. Don't break after you find a suitable edge.
2. Remove the edge from the array of all edges after you use it so that it is not available in the next iteration. That's what this PR does.

---

Bottomline1: Why exactly do you have to know the correct order of edges in order to sum their weight?
Bottomline2: Why do you have to sort the edges at all? Shouldn't the distinct algorithms logically know the order and return the edges in the right order?

Anyway we plan to use this library for warehouse optimization purposes and plan to use it on graphs with hundreds of vertices. It is quite possible that more PRs will follow :)
