### PR TITLE
Fixed Image::setFormat() sets Image::type instead of Image::format.

### DIFF
--- a/lib/Fhaculty/Graph/Exporter/Image.php
+++ b/lib/Fhaculty/Graph/Exporter/Image.php
@@ -8,24 +8,24 @@ use Fhaculty\Graph\Graph;
 class Image implements ExporterInterface
 {
     private $format = 'png';
-    
+
     public function getOutput(Graph $graph)
     {
         $graphviz = new GraphViz($graph);
         $graphviz->setFormat($this->format);
         return $graphviz->createImageData();
     }
-    
+
     /**
      * set the image output format to use
-     * 
+     *
      * @param string $type png, svg
      * @return self $this (chainable)
      * @see GraphViz::setFormat()
      */
     public function setFormat($type)
     {
-        $this->type = $type;
+        $this->format = $type;
         return $this;
     }
 }


### PR DESCRIPTION
This caused all images to be generated as PNG.
