### PR TITLE
GraphViz HTML-Like Labels

### DIFF
--- a/lib/Fhaculty/Graph/GraphViz.php
+++ b/lib/Fhaculty/Graph/GraphViz.php
@@ -408,7 +408,7 @@ class GraphViz
                 $script .= ' ';
             }
             // Allowed attributes for http://www.graphviz.org/doc/info/shapes.html#html
-            if (in_array($name, array('label', 'headtail', 'taillabel'))) {
+            if (!is_object($value) && in_array($name, array('label', 'headtail', 'taillabel'))) {
                 if (preg_match("/^\<\<.*\>\>$/", $value)) {
                     $value = self::raw($value);
                 }


### PR DESCRIPTION
This fixes https://github.com/clue/graph-uml/issues/5

The PR is just a pinpoint effort.
- [ ] Add newline for the <...> construct defined in http://www.graphviz.org/doc/info/shapes.html#html
- [ ] How should we deal with ie `<<interface>>` ?
