### PR TITLE
Add reference to additional shortest-path possibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Therefore this library is being used as the basis for implementations for a numb
     * [Dijkstra](https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm)
     * Moore-Bellman-Ford (MBF)
     * Counting number of hops (simple BFS)
+    * A* (through a [third party extension](https://github.com/Stratadox/GraphpFinder))
+    * Floyd-Warshall (through a [third party extension](https://github.com/Stratadox/GraphpFinder))
 * [Minimum spanning tree (MST)](https://en.wikipedia.org/wiki/Minimum_spanning_tree)
     * Kruskal
     * Prim


### PR DESCRIPTION
This pull request adds references to a [graphp adapter](https://github.com/Stratadox/GraphpFinder), which unlocks the algorithms implemented in the [Pathfinder](https://github.com/Stratadox/Pathfinder) module.

The link with the Pathfinder module enables using the A* and Floyd-Warshall algorithms, providing a valuable addition to the current shortest paths arsenal.