### PR TITLE
Move creating edges to `Graph`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ $madrid = $graph->createVertex('Madrid');
 $cologne = $graph->createVertex('Cologne');
 
 // build some roads
-$cologne->createEdgeTo($madrid);
-$madrid->createEdgeTo($rome);
+$graph->createEdgeDirected($cologne, $madrid);
+$graph->createEdgeDirected($madrid, $rome);
 // create loop
-$rome->createEdgeTo($rome);
+$graph->createEdgeDirected($rome, $rome);
 ```
 
 Let's see which city (Vertex) has a road (i.e. an edge pointing) to Rome:

--- a/src/Edge/Directed.php
+++ b/src/Edge/Directed.php
@@ -3,6 +3,7 @@
 namespace Graphp\Graph\Edge;
 
 use Graphp\Graph\Exception\InvalidArgumentException;
+use Graphp\Graph\Graph;
 use Graphp\Graph\Set\Vertices;
 use Graphp\Graph\Vertex;
 
@@ -23,12 +24,13 @@ class Directed extends Base
     private $to;
 
     /**
-     * create a new directed Edge from Vertex $from to Vertex $to
+     * [Internal] Create a new directed Edge from Vertex $from to Vertex $to
      *
      * @param Vertex $from start/source Vertex
      * @param Vertex $to   end/target Vertex
-     * @see Vertex::createEdgeTo() to create directed edges
-     * @see Vertex::createEdge() to create undirected edges
+     * @see Graph::createEdgeDirected() to create directed edges
+     * @see Graph::createEdgeUndirected() to create undirected edges
+     * @internal
      */
     public function __construct(Vertex $from, Vertex $to)
     {

--- a/src/Edge/Undirected.php
+++ b/src/Edge/Undirected.php
@@ -3,6 +3,7 @@
 namespace Graphp\Graph\Edge;
 
 use Graphp\Graph\Exception\InvalidArgumentException;
+use Graphp\Graph\Graph;
 use Graphp\Graph\Vertex;
 use Graphp\Graph\Set\Vertices;
 
@@ -23,11 +24,13 @@ class Undirected extends Base
     private $b;
 
     /**
-     * create a new undirected edge between given vertices
+     * [Internal] Create a new undirected edge between given vertices
      *
      * @param Vertex $a
      * @param Vertex $b
-     * @see Vertex::createEdge() instead
+     * @see Graph::createEdgeUndirected() to create undirected edges
+     * @see Graph::createEdgeDirected() to create directed edges
+     * @internal
      */
     public function __construct(Vertex $a, Vertex $b)
     {

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -6,6 +6,7 @@ use Graphp\Graph\Attribute\AttributeAware;
 use Graphp\Graph\Attribute\AttributeBagReference;
 use Graphp\Graph\Edge\Base as Edge;
 use Graphp\Graph\Edge\Directed as EdgeDirected;
+use Graphp\Graph\Edge\Undirected as EdgeUndirected;
 use Graphp\Graph\Exception\BadMethodCallException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Exception\OutOfBoundsException;
@@ -111,7 +112,7 @@ class Graph implements DualAggregate, AttributeAware
         $graph->getAttributeBag()->setAttributes($this->getAttributeBag()->getAttributes());
         // TODO: set additional graph attributes
         foreach ($this->getVertices() as $originalVertex) {
-            $vertex = $graph->createVertexClone($originalVertex);
+            $graph->createVertexClone($originalVertex);
             // $graph->vertices[$vid] = $vertex;
         }
 
@@ -170,6 +171,40 @@ class Graph implements DualAggregate, AttributeAware
     }
 
     /**
+     * Creates a new undirected (bidirectional) edge between the given two vertices.
+     *
+     * @param  Vertex                   $a
+     * @param  Vertex                   $b
+     * @return EdgeUndirected
+     * @throws InvalidArgumentException
+     */
+    public function createEdgeUndirected(Vertex $a, Vertex $b)
+    {
+        if ($a->getGraph() !== $this) {
+            throw new InvalidArgumentException('Vertices have to be within this graph');
+        }
+
+        return new EdgeUndirected($a, $b);
+    }
+
+    /**
+     * Creates a new directed edge from the given start vertex to given target vertex
+     *
+     * @param  Vertex                   $source source vertex
+     * @param  Vertex                   $target target vertex
+     * @return EdgeDirected
+     * @throws InvalidArgumentException
+     */
+    public function createEdgeDirected(Vertex $source, Vertex $target)
+    {
+        if ($source->getGraph() !== $this) {
+            throw new InvalidArgumentException('Vertices have to be within this graph');
+        }
+
+        return new EdgeDirected($source, $target);
+    }
+
+    /**
      * create new clone of the given edge between adjacent vertices
      *
      * @param  Edge $originalEdge original edge (not neccessarily from this graph)
@@ -202,8 +237,8 @@ class Graph implements DualAggregate, AttributeAware
      * @return Edge new edge in this graph
      * @uses Edge::getVertices()
      * @uses Graph::getVertex()
-     * @uses Vertex::createEdge() to create a new undirected edge if given edge was undrected
-     * @uses Vertex::createEdgeTo() to create a new directed edge if given edge was directed
+     * @uses Vertex::createEdgeUndirected() to create a new undirected edge if given edge was undrected
+     * @uses Vertex::createEdgeDirected() to create a new directed edge if given edge was directed
      * @uses Edge::getWeight()
      * @uses Edge::setWeight()
      * @uses Edge::getFlow()
@@ -221,10 +256,10 @@ class Graph implements DualAggregate, AttributeAware
         $b = $this->getVertex($ends[$ib]);
 
         if ($originalEdge instanceof EdgeDirected) {
-            $newEdge = $a->createEdgeTo($b);
+            $newEdge = $this->createEdgeDirected($a, $b);
         } else {
             // create new edge between new a and b
-            $newEdge = $a->createEdge($b);
+            $newEdge = $this->createEdgeUndirected($a, $b);
         }
         // TODO: copy edge attributes
         $newEdge->getAttributeBag()->setAttributes($originalEdge->getAttributeBag()->getAttributes());
@@ -337,7 +372,7 @@ class Graph implements DualAggregate, AttributeAware
      * @param  Edge $edge instance of the new Edge
      * @return void
      * @internal
-     * @see Vertex::createEdge() instead!
+     * @see Graph::createEdgeUndirected() instead!
      */
     public function addEdge(Edge $edge)
     {

--- a/src/Vertex.php
+++ b/src/Vertex.php
@@ -6,7 +6,6 @@ use Graphp\Graph\Attribute\AttributeAware;
 use Graphp\Graph\Attribute\AttributeBagReference;
 use Graphp\Graph\Edge\Base as Edge;
 use Graphp\Graph\Edge\Directed as EdgeDirected;
-use Graphp\Graph\Edge\Undirected as EdgeUndirected;
 use Graphp\Graph\Exception\BadMethodCallException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Set\Edges;
@@ -127,38 +126,12 @@ class Vertex implements EdgesAggregate, AttributeAware
     }
 
     /**
-     * create new directed edge from this start vertex to given target vertex
-     *
-     * @param  Vertex                   $vertex target vertex
-     * @return EdgeDirected
-     * @throws InvalidArgumentException
-     * @uses Graph::addEdge()
-     */
-    public function createEdgeTo(Vertex $vertex)
-    {
-        return new EdgeDirected($this, $vertex);
-    }
-
-    /**
-     * add new undirected (bidirectional) edge between this vertex and given vertex
-     *
-     * @param  Vertex                   $vertex
-     * @return EdgeUndirected
-     * @throws InvalidArgumentException
-     * @uses Graph::addEdge()
-     */
-    public function createEdge(Vertex $vertex)
-    {
-        return new EdgeUndirected($this, $vertex);
-    }
-
-    /**
      * add the given edge to list of connected edges (MUST NOT be called manually)
      *
      * @param  Edge                     $edge
      * @return void
      * @internal
-     * @see self::createEdge() instead!
+     * @see Graph::createEdgeUndirected() instead!
      */
     public function addEdge(Edge $edge)
     {

--- a/tests/Edge/EdgeAttributesTest.php
+++ b/tests/Edge/EdgeAttributesTest.php
@@ -22,7 +22,7 @@ class EdgeAttributesTest extends TestCase
         $graph->createVertex(2);
 
         // 1 -> 2
-        $this->edge = $graph->getVertex(1)->createEdge($graph->getVertex(2));
+        $this->edge = $graph->createEdgeUndirected($graph->getVertex(1), $graph->getVertex(2));
     }
 
     public function testCanSetFlowAndCapacity()

--- a/tests/Edge/EdgeBaseTest.php
+++ b/tests/Edge/EdgeBaseTest.php
@@ -18,7 +18,7 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
      */
     protected $edge;
 
-    abstract protected function createEdge();
+    abstract protected function createEdgeUndirected();
 
     /**
      * @return Edge
@@ -31,7 +31,7 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
         $this->v1 = $this->graph->createVertex(1);
         $this->v2 = $this->graph->createVertex(2);
 
-        $this->edge = $this->createEdge();
+        $this->edge = $this->createEdgeUndirected();
     }
 
     public function testEdgeVertices()
@@ -113,6 +113,6 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
 
     protected function createAttributeAware()
     {
-        return $this->createEdge();
+        return $this->createEdgeUndirected();
     }
 }

--- a/tests/Edge/EdgeDirectedTest.php
+++ b/tests/Edge/EdgeDirectedTest.php
@@ -4,10 +4,10 @@ namespace Graphp\Graph\Tests\Edge;
 
 class EdgeDirectedTest extends EdgeBaseTest
 {
-    protected function createEdge()
+    protected function createEdgeUndirected()
     {
         // 1 -> 2
-        return $this->v1->createEdgeTo($this->v2);
+        return $this->graph->createEdgeDirected($this->v1, $this->v2);
     }
 
     protected function createEdgeLoop()
@@ -15,7 +15,7 @@ class EdgeDirectedTest extends EdgeBaseTest
         // 1 --\
         // ^   |
         // \---/
-        return $this->v1->createEdgeTo($this->v1);
+        return $this->graph->createEdgeDirected($this->v1, $this->v1);
     }
 
     public function testVerticesEnds()

--- a/tests/Edge/EdgeUndirectedTest.php
+++ b/tests/Edge/EdgeUndirectedTest.php
@@ -4,10 +4,10 @@ namespace Graphp\Graph\Tests\Edge;
 
 class EdgeUndirectedTest extends EdgeBaseTest
 {
-    protected function createEdge()
+    protected function createEdgeUndirected()
     {
         // 1 -- 2
-        return $this->v1->createEdge($this->v2);
+        return $this->graph->createEdgeUndirected($this->v1, $this->v2);
     }
 
     protected function createEdgeLoop()
@@ -15,7 +15,7 @@ class EdgeUndirectedTest extends EdgeBaseTest
         // 1 --\
         // |   |
         // \---/
-        return $this->v1->createEdge($this->v1);
+        return $this->graph->createEdgeUndirected($this->v1, $this->v1);
     }
 
     public function testVerticesEnds()

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -70,8 +70,8 @@ class GraphTest extends AbstractAttributeAwareTest
     public function testGraphCloneEdgeless()
     {
         $graph = new Graph();
-        $graph->createVertex(1)->createEdgeTo($graph->createVertex(2));
-        $graph->createVertex(3)->createEdge($graph->getVertex(2));
+        $graph->createEdgeDirected($graph->createVertex(1), $graph->createVertex(2));
+        $graph->createEdgeUndirected($graph->createVertex(3), $graph->getVertex(2));
 
         $graphEdgeless = $graph->createGraphCloneEdgeless();
 
@@ -118,7 +118,7 @@ class GraphTest extends AbstractAttributeAwareTest
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testCreateInvalidId()
+    public function testCreateVertexWithInvalidIdThrows()
     {
         $graph = new Graph();
         $graph->createVertex(array('invalid'));
@@ -132,6 +132,34 @@ class GraphTest extends AbstractAttributeAwareTest
         $v1again = $graph->createVertex(1, true);
 
         $this->assertSame($v1, $v1again);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateEdgeUndirectedWithVerticesFromOtherGraphThrows()
+    {
+        // 1, 2
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+
+        $graph2 = new Graph();
+        $graph2->createEdgeUndirected($v1, $v2);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCreateEdgeDirectedWithVerticesFromOtherGraphThrows()
+    {
+        // 1, 2
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+
+        $graph2 = new Graph();
+        $graph2->createEdgeDirected($v1, $v2);
     }
 
     public function testHasVertex()
@@ -157,9 +185,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-
-        $e1 = $v1->createEdge($v2);
-        $e2 = $v1->createEdge($v2);
+        $graph->createEdgeUndirected($v1, $v2);
+        $graph->createEdgeUndirected($v1, $v2);
 
         $this->assertEquals(2, count($graph->getEdges()));
         $this->assertEquals(2, count($v1->getEdges()));
@@ -175,8 +202,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $v2 = $graph->createVertex(2);
         $v3 = $graph->createVertex(3);
 
-        $v1->createEdge($v2);
-        $v2->createEdgeTo($v3);
+        $graph->createEdgeUndirected($v1, $v2);
+        $graph->createEdgeDirected($v2, $v3);
 
         $this->assertEquals(2, count($graph->getEdges()));
 
@@ -277,7 +304,7 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $edge = $v1->createEdge($v2);
+        $edge = $graph->createEdgeUndirected($v1, $v2);
 
         $this->assertEquals(array($edge), $graph->getEdges()->getVector());
 
@@ -296,7 +323,7 @@ class GraphTest extends AbstractAttributeAwareTest
      */
     public function testRemoveEdgeInvalid(Graph $graph)
     {
-        $edge = $graph->getVertex(1)->createEdge($graph->getVertex(2));
+        $edge = $graph->createEdgeUndirected($graph->getVertex(1), $graph->getVertex(2));
 
         $edge->destroy();
         $edge->destroy();
@@ -332,8 +359,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v2->createEdgeTo($v1);
+        $e1 = $graph->createEdgeDirected($v1, $v2);
+        $e2 = $graph->createEdgeDirected($v2, $v1);
 
         $graphClone = $graph->createGraphClone();
 
@@ -350,8 +377,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v1->createEdgeTo($v2);
+        $e1 = $graph->createEdgeDirected($v1, $v2);
+        $graph->createEdgeDirected($v1, $v2);
 
         // which one to return? e1? e2?
         $graph->getEdgeClone($e1);
@@ -366,8 +393,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v1->createEdgeTo($v2);
+        $e1 = $graph->createEdgeDirected($v1, $v2);
+        $graph->createEdgeDirected($v1, $v2);
 
         $graphCloneEdgeless = $graph->createGraphCloneEdgeless();
 
@@ -382,8 +409,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
         $v3 = $graph->createVertex(3);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v2->createEdgeTo($v3);
+        $graph->createEdgeDirected($v1, $v2);
+        $graph->createEdgeDirected($v2, $v3);
 
         $graphClone = $graph->createGraphCloneVertices(array(1 => $v1, 2 => $v2));
 

--- a/tests/Set/EdgesTest.php
+++ b/tests/Set/EdgesTest.php
@@ -24,7 +24,7 @@ class EdgesTest extends TestCase
         // 1 -> 1
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
-        $e1 = $v1->createEdgeTo($v1);
+        $e1 = $graph->createEdgeDirected($v1, $v1);
 
         $edgesFromArray = $this->createEdges(array($e1));
         $this->assertInstanceOf('Graphp\Graph\Set\Edges', $edgesFromArray);
@@ -90,8 +90,8 @@ class EdgesTest extends TestCase
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
         $v3 = $graph->createVertex(3);
-        $e1 = $v1->createEdge($v2);
-        $e2 = $v2->createEdge($v3);
+        $e1 = $graph->createEdgeUndirected($v1, $v2);
+        $e2 = $graph->createEdgeUndirected($v2, $v3);
 
         $edges = $this->createEdges(array($e1, $e2));
 
@@ -129,7 +129,7 @@ class EdgesTest extends TestCase
     {
         $graph = new Graph();
         $v3 = $graph->createVertex(3);
-        $e3 = $v3->createEdge($v3);
+        $e3 = $graph->createEdgeUndirected($v3, $v3);
 
         $edges->getIndexEdge($e3);
     }
@@ -232,7 +232,7 @@ class EdgesTest extends TestCase
         // 1 -> 1
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
-        $v1->createEdgeTo($v1);
+        $graph->createEdgeDirected($v1, $v1);
 
         $edges = $graph->getEdges();
 
@@ -254,13 +254,13 @@ class EdgesTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $v1->createEdge($v2)->setWeight(1);
-        $v1->createEdge($v2)->setWeight(100);
-        $v1->createEdge($v2)->setWeight(5);
-        $v1->createEdge($v2)->setWeight(100);
-        $v1->createEdge($v2)->setWeight(100);
-        $v1->createEdge($v2)->setWeight(2);
-        $biggest = $v1->createEdge($v2)->setWeight(200);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(1);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(100);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(5);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(100);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(100);
+        $graph->createEdgeUndirected($v1, $v2)->setWeight(2);
+        $biggest = $graph->createEdgeUndirected($v1, $v2)->setWeight(200);
 
         $edges = $graph->getEdges();
         $edgesOrdered = $edges->getEdgesOrder(Edges::ORDER_WEIGHT);
@@ -284,9 +284,9 @@ class EdgesTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdge($v2);
-        $e2 = $v1->createEdge($v2);
-        $e3 = $v1->createEdge($v2);
+        $e1 = $graph->createEdgeUndirected($v1, $v2);
+        $e2 = $graph->createEdgeUndirected($v1, $v2);
+        $e3 = $graph->createEdgeUndirected($v1, $v2);
 
         $edges1 = $this->createEdges(array($e1, $e2));
         $edges2 = $this->createEdges(array($e2, $e3));
@@ -301,7 +301,7 @@ class EdgesTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdge($v2);
+        $e1 = $graph->createEdgeUndirected($v1, $v2);
 
         $edges1 = $this->createEdges(array($e1, $e1, $e1));
         $edges2 = $this->createEdges(array($e1, $e1));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,7 +28,7 @@ class TestCase extends BaseTestCase
         // do not use assertVertexEquals() in order to not increase assertion counter
 
         foreach ($expected->getVertices()->getMap() as $vid => $vertex) {
-            $other = $actual->getVertex($vid);
+            $actual->getVertex($vid);
 
             if ($this->getVertexDump($vertex) !== $this->getVertexDump($vertex)) {
                 $this->fail();

--- a/tests/VertexTest.php
+++ b/tests/VertexTest.php
@@ -8,6 +8,9 @@ use Graphp\Graph\Vertex;
 
 class VertexTest extends AbstractAttributeAwareTest
 {
+    private $graph;
+    private $vertex;
+
     public function setUp()
     {
         $this->graph = new Graph();
@@ -37,7 +40,7 @@ class VertexTest extends AbstractAttributeAwareTest
      */
     public function testCanNotConstructDuplicateVertex()
     {
-        $v2 = new Vertex($this->graph, 1);
+        new Vertex($this->graph, 1);
     }
 
     public function testEdges()
@@ -46,9 +49,9 @@ class VertexTest extends AbstractAttributeAwareTest
         $v2 = $this->graph->createVertex(2);
         $v3 = $this->graph->createVertex(3);
         $v4 = $this->graph->createVertex(4);
-        $e1 = $this->vertex->createEdgeTo($v2);
-        $e2 = $this->vertex->createEdge($v3);
-        $e3 = $v4->createEdgeTo($this->vertex);
+        $e1 = $this->graph->createEdgeDirected($this->vertex, $v2);
+        $e2 = $this->graph->createEdgeUndirected($this->vertex, $v3);
+        $e3 = $this->graph->createEdgeDirected($v4, $this->vertex);
 
         $this->assertEquals(array($e1, $e2, $e3), $this->vertex->getEdges()->getVector());
         $this->assertEquals(array($e2, $e3), $this->vertex->getEdgesIn()->getVector());
@@ -77,7 +80,7 @@ class VertexTest extends AbstractAttributeAwareTest
 
     public function testUndirectedLoopEdgeReturnsEdgeTwiceInAndOut()
     {
-        $edge = $this->vertex->createEdge($this->vertex);
+        $edge = $this->graph->createEdgeUndirected($this->vertex, $this->vertex);
 
         $this->assertEquals(array($edge, $edge), $this->vertex->getEdges()->getVector());
         $this->assertEquals(array($edge, $edge), $this->vertex->getEdgesIn()->getVector());
@@ -90,7 +93,7 @@ class VertexTest extends AbstractAttributeAwareTest
 
     public function testDirectedLoopEdgeReturnsEdgeTwiceUndirectedAndOnceEachInAndOut()
     {
-        $edge = $this->vertex->createEdgeTo($this->vertex);
+        $edge = $this->graph->createEdgeDirected($this->vertex, $this->vertex);
 
         $this->assertEquals(array($edge, $edge), $this->vertex->getEdges()->getVector());
         $this->assertEquals(array($edge), $this->vertex->getEdgesIn()->getVector());
@@ -136,17 +139,17 @@ class VertexTest extends AbstractAttributeAwareTest
     {
         $graphOther = new Graph();
 
-        $this->vertex->createEdge($graphOther->createVertex(2));
+        $this->graph->createEdgeUndirected($this->vertex, $graphOther->createVertex(2));
     }
 
     /**
      * @expectedException InvalidArgumentException
      */
-    public function testCreateEdgeToOtherGraphFails()
+    public function testcreateEdgeDirectedOtherGraphFails()
     {
         $graphOther = new Graph();
 
-        $this->vertex->createEdgeTo($graphOther->createVertex(2));
+        $this->graph->createEdgeDirected($this->vertex, $graphOther->createVertex(2));
     }
 
     /**
@@ -157,7 +160,7 @@ class VertexTest extends AbstractAttributeAwareTest
         // 2 -- 3
         $v2 = $this->graph->createVertex(2);
         $v3 = $this->graph->createVertex(3);
-        $edge = $v2->createEdge($v3);
+        $edge = $this->graph->createEdgeUndirected($v2, $v3);
 
         $this->vertex->removeEdge($edge);
     }
@@ -165,7 +168,7 @@ class VertexTest extends AbstractAttributeAwareTest
     public function testRemoveWithEdgeLoopUndirected()
     {
         // 1 -- 1
-        $edge = $this->vertex->createEdge($this->vertex);
+        $this->graph->createEdgeUndirected($this->vertex, $this->vertex);
 
         $this->assertEquals(array(1 => $this->vertex), $this->graph->getVertices()->getMap());
 
@@ -178,7 +181,7 @@ class VertexTest extends AbstractAttributeAwareTest
     public function testRemoveWithEdgeLoopDirected()
     {
         // 1 --> 1
-        $edge = $this->vertex->createEdgeTo($this->vertex);
+        $this->graph->createEdgeDirected($this->vertex, $this->vertex);
 
         $this->assertEquals(array(1 => $this->vertex), $this->graph->getVertices()->getMap());
 

--- a/tests/WalkTest.php
+++ b/tests/WalkTest.php
@@ -24,8 +24,8 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
         $v3 = $graph->createVertex(3);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v2->createEdgeTo($v3);
+        $e1 = $graph->createEdgeDirected($v1, $v2);
+        $e2 = $graph->createEdgeDirected($v2, $v3);
 
         $walk = Walk::factoryFromEdges(array($e1, $e2), $v1);
 
@@ -61,8 +61,8 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
         $v3 = $graph->createVertex(3);
-        $e1 = $v1->createEdgeTo($v2);
-        $e2 = $v2->createEdgeTo($v3);
+        $e1 = $graph->createEdgeDirected($v1, $v2);
+        $graph->createEdgeDirected($v2, $v3);
 
         // construct partial walk "1 -- 2"
         $walk = Walk::factoryFromEdges(array($e1), $v1);
@@ -75,7 +75,7 @@ class WalkTest extends TestCase
         $this->assertTrue($walk->isValid());
 
         $graphExpected = new Graph();
-        $graphExpected->createVertex(1)->createEdgeTo($graphExpected->createVertex(2));
+        $graphExpected->createEdgeDirected($graphExpected->createVertex(1), $graphExpected->createVertex(2));
 
         $this->assertGraphEquals($graphExpected, $walk->createGraph());
 
@@ -95,7 +95,7 @@ class WalkTest extends TestCase
         // 1 -- 1
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
-        $e1 = $v1->createEdge($v1);
+        $e1 = $graph->createEdgeUndirected($v1, $v1);
 
         $walk = Walk::factoryFromEdges(array($e1), $v1);
 
@@ -128,7 +128,7 @@ class WalkTest extends TestCase
         // 1 -- 1
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
-        $e1 = $v1->createEdge($v1);
+        $e1 = $graph->createEdgeUndirected($v1, $v1);
 
         $walk = Walk::factoryCycleFromEdges(array($e1), $v1);
 
@@ -148,8 +148,8 @@ class WalkTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdge($v2);
-        $e2 = $v2->createEdge($v1);
+        $graph->createEdgeUndirected($v1, $v2);
+        $graph->createEdgeUndirected($v2, $v1);
 
         // should actually be [v1, v2, v1]
         Walk::factoryCycleFromVertices(array($v1, $v2));
@@ -164,7 +164,7 @@ class WalkTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdge($v2);
+        $e1 = $graph->createEdgeUndirected($v1, $v2);
 
         Walk::factoryCycleFromEdges(array($e1), $v1);
     }
@@ -176,7 +176,7 @@ class WalkTest extends TestCase
         // \---/
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
-        $e1 = $v1->createEdgeTo($v1);
+        $e1 = $graph->createEdgeDirected($v1, $v1);
 
         $cycle = Walk::factoryCycleFromEdges(array($e1), $v1);
         $this->assertGraphEquals($graph, $cycle->createGraph());
@@ -226,8 +226,8 @@ class WalkTest extends TestCase
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
         $v2 = $graph->createVertex(2);
-        $e1 = $v1->createEdge($v2)->setWeight(10);
-        $e2 = $v1->createEdge($v2)->setWeight(20);
+        $e1 = $graph->createEdgeUndirected($v1, $v2)->setWeight(10);
+        $e2 = $graph->createEdgeUndirected($v1, $v2)->setWeight(20);
 
         // any edge in walk
         $walk = Walk::factoryFromVertices(array($v1, $v2));


### PR DESCRIPTION
The new API is now much more consistent with all other `create*()`
methods and makes the distinction between undirected and directed edges
more explicit:

```php
// old
$v1->createEdge($v2);
$v1->createEdgeTo($v2);

// new
$graph->createEdgeUndirected($v1, $v2);
$graph->createEdgeDirected($v1, $v2);
```