### PR TITLE
Remove edge cloning alias methods, use Graph instead

### DIFF
--- a/src/Edge/Base.php
+++ b/src/Edge/Base.php
@@ -258,28 +258,6 @@ abstract class Base implements VerticesAggregate, AttributeAware
     }
 
     /**
-     * create new clone of this edge between adjacent vertices
-     *
-     * @return self new edge
-     * @uses Graph::createEdgeClone()
-     */
-    public function createEdgeClone()
-    {
-        return $this->getGraph()->createEdgeClone($this);
-    }
-
-    /**
-     * create new clone of this edge inverted (in opposite direction) between adjacent vertices
-     *
-     * @return self new edge
-     * @uses Graph::createEdgeCloneInverted()
-     */
-    public function createEdgeCloneInverted()
-    {
-        return $this->getGraph()->createEdgeCloneInverted($this);
-    }
-
-    /**
      * do NOT allow cloning of objects
      *
      * @throws BadMethodCallException

--- a/src/Walk.php
+++ b/src/Walk.php
@@ -204,31 +204,6 @@ class Walk implements DualAggregate
     }
 
     /**
-     * create new graph clone with only vertices and edges actually in the walk
-     *
-     * do not add duplicate vertices and edges for loops and intersections, etc.
-     *
-     * @return Graph
-     * @uses Walk::getEdges()
-     * @uses Graph::createGraphCloneEdges()
-     */
-    public function createGraph()
-    {
-        // create new graph clone with only edges of walk
-        $graph = $this->getGraph()->createGraphCloneEdges($this->getEdges());
-        $vertices = $this->getVertices()->getMap();
-        // get all vertices
-        foreach ($graph->getVertices()->getMap() as $vid => $vertex) {
-            if (!isset($vertices[$vid])) {
-                // remove those not present in the walk (isolated vertices, etc.)
-                $vertex->destroy();
-            }
-        }
-
-        return $graph;
-    }
-
-    /**
      * return set of all Edges of walk (in sequence visited in walk, may contain duplicates)
      *
      * If you need to return set a of all unique Edges of walk, use

--- a/tests/Edge/EdgeBaseTest.php
+++ b/tests/Edge/EdgeBaseTest.php
@@ -71,24 +71,6 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
         $this->edge->getVertexToFrom($v3);
     }
 
-    public function testClone()
-    {
-        $edge = $this->edge->createEdgeClone();
-
-        $this->assertEdgeEquals($this->edge, $edge);
-    }
-
-    public function testCloneDoubleInvertedIsOriginal()
-    {
-        $edgeInverted = $this->edge->createEdgeCloneInverted();
-
-        $this->assertInstanceOf(get_class($this->edge), $edgeInverted);
-
-        $edge = $edgeInverted->createEdgeCloneInverted();
-
-        $this->assertEdgeEquals($this->edge, $edge);
-    }
-
     public function testLoop()
     {
         $edge = $this->createEdgeLoop();

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -298,6 +298,38 @@ class GraphTest extends AbstractAttributeAwareTest
         $graph->createVertices(array(1, 2, array(), 3));
     }
 
+    public function testCloneInvertedUndirectedIsAlmostOriginal()
+    {
+        // 1 -- 2
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+        $edge = $graph->createEdgeUndirected($v1, $v2);
+
+        $edgeInverted = $graph->createEdgeCloneInverted($edge);
+
+        $this->assertInstanceOf(get_class($edge), $edgeInverted);
+
+        $this->assertEquals($edge->getVertices()->getVector(), array_reverse($edgeInverted->getVertices()->getVector()));
+    }
+
+    public function testCloneDoubleInvertedDirectedEdgeIsOriginal()
+    {
+        // 1 -> 2
+        $graph = new Graph();
+        $v1 = $graph->createVertex(1);
+        $v2 = $graph->createVertex(2);
+        $edge = $graph->createEdgeDirected($v1, $v2);
+
+        $edgeInverted = $graph->createEdgeCloneInverted($edge);
+
+        $this->assertInstanceOf(get_class($edge), $edgeInverted);
+
+        $edgeInvertedAgain = $graph->createEdgeCloneInverted($edgeInverted);
+
+        $this->assertEdgeEquals($edge, $edgeInvertedAgain);
+    }
+
     public function testRemoveEdge()
     {
         // 1 -- 2


### PR DESCRIPTION
```php
// old (removed alias methods)
$new = $edge->createEdgeClone();
$inverted = $edge->createEdgeCloneInverted();

// new (already supported before)
$new = $graph->createEdgeClone($edge);
$inverted = $graph->createEdgeCloneInverted($edge);

// old (rarely used)
$walkGraph = $walk->createGraph();

// new (already supported before)
$walkGraph = $graph
    ->createGraphCloneEdges($walk->getEdges())
    ->createGraphCloneVertices($walk->getVertices());
```

Builds on top of #175