### PR TITLE
Rename Edge classes to Edge, EdgeUndirected and EdgeDirected

### DIFF
--- a/src/Edge.php
+++ b/src/Edge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Graphp\Graph\Edge;
+namespace Graphp\Graph;
 
 use Graphp\Graph\Attribute\AttributeAware;
 use Graphp\Graph\Attribute\AttributeBagReference;
@@ -8,12 +8,16 @@ use Graphp\Graph\Exception\BadMethodCallException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Exception\LogicException;
 use Graphp\Graph\Exception\RangeException;
-use Graphp\Graph\Graph;
 use Graphp\Graph\Set\Vertices;
 use Graphp\Graph\Set\VerticesAggregate;
-use Graphp\Graph\Vertex;
 
-abstract class Base implements VerticesAggregate, AttributeAware
+/**
+ * Abstract base for `EdgeUndirected` and `EdgeDirected` containing common interfaces and behavior for all edges.
+ *
+ * @see EdgeUndirected
+ * @see EdgeDirected
+ */
+abstract class Edge implements VerticesAggregate, AttributeAware
 {
     /**
      * weight of this edge

--- a/src/EdgeDirected.php
+++ b/src/EdgeDirected.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace Graphp\Graph\Edge;
+namespace Graphp\Graph;
 
 use Graphp\Graph\Exception\InvalidArgumentException;
-use Graphp\Graph\Graph;
 use Graphp\Graph\Set\Vertices;
-use Graphp\Graph\Vertex;
 
-class Directed extends Base
+class EdgeDirected extends Edge
 {
     /**
      * source/start vertex

--- a/src/EdgeUndirected.php
+++ b/src/EdgeUndirected.php
@@ -1,13 +1,11 @@
 <?php
 
-namespace Graphp\Graph\Edge;
+namespace Graphp\Graph;
 
 use Graphp\Graph\Exception\InvalidArgumentException;
-use Graphp\Graph\Graph;
-use Graphp\Graph\Vertex;
 use Graphp\Graph\Set\Vertices;
 
-class Undirected extends Base
+class EdgeUndirected extends Edge
 {
     /**
      * vertex a

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -4,9 +4,6 @@ namespace Graphp\Graph;
 
 use Graphp\Graph\Attribute\AttributeAware;
 use Graphp\Graph\Attribute\AttributeBagReference;
-use Graphp\Graph\Edge\Base as Edge;
-use Graphp\Graph\Edge\Directed as EdgeDirected;
-use Graphp\Graph\Edge\Undirected as EdgeUndirected;
 use Graphp\Graph\Exception\BadMethodCallException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Exception\OutOfBoundsException;

--- a/src/Set/Edges.php
+++ b/src/Set/Edges.php
@@ -2,7 +2,7 @@
 
 namespace Graphp\Graph\Set;
 
-use Graphp\Graph\Edge\Base as Edge;
+use Graphp\Graph\Edge;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Exception\OutOfBoundsException;
 use Graphp\Graph\Exception\UnderflowException;

--- a/src/Vertex.php
+++ b/src/Vertex.php
@@ -4,8 +4,6 @@ namespace Graphp\Graph;
 
 use Graphp\Graph\Attribute\AttributeAware;
 use Graphp\Graph\Attribute\AttributeBagReference;
-use Graphp\Graph\Edge\Base as Edge;
-use Graphp\Graph\Edge\Directed as EdgeDirected;
 use Graphp\Graph\Exception\BadMethodCallException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Set\Edges;

--- a/src/Walk.php
+++ b/src/Walk.php
@@ -4,7 +4,6 @@ namespace Graphp\Graph;
 
 use Graphp\Graph\Set\Edges;
 use Graphp\Graph\Set\Vertices;
-use Graphp\Graph\Edge\Base as Edge;
 use Graphp\Graph\Exception\UnderflowException;
 use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Set\DualAggregate;

--- a/tests/EdgeAttributesTest.php
+++ b/tests/EdgeAttributesTest.php
@@ -1,15 +1,13 @@
 <?php
 
-namespace Graphp\Graph\Tests\Edge;
+namespace Graphp\Graph\Tests;
 
 use Graphp\Graph\Graph;
-use Graphp\Graph\Edge\Base as Edge;
-use Graphp\Graph\Tests\TestCase;
+use Graphp\Graph\Edge;
 
 class EdgeAttributesTest extends TestCase
 {
     /**
-     *
      * @var Edge
      */
     private $edge;

--- a/tests/EdgeBaseTest.php
+++ b/tests/EdgeBaseTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Graphp\Graph\Tests\Edge;
+namespace Graphp\Graph\Tests;
 
 use Graphp\Graph\Graph;
-use Graphp\Graph\Edge\Base as Edge;
+use Graphp\Graph\Edge;
 use Graphp\Graph\Tests\Attribute\AbstractAttributeAwareTest;
 
 abstract class EdgeBaseTest extends AbstractAttributeAwareTest
@@ -13,7 +13,6 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
     protected $v2;
 
     /**
-     *
      * @var Edge
      */
     protected $edge;

--- a/tests/EdgeDirectedTest.php
+++ b/tests/EdgeDirectedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Graphp\Graph\Tests\Edge;
+namespace Graphp\Graph\Tests;
 
 class EdgeDirectedTest extends EdgeBaseTest
 {

--- a/tests/EdgeUndirectedTest.php
+++ b/tests/EdgeUndirectedTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Graphp\Graph\Tests\Edge;
+namespace Graphp\Graph\Tests;
 
 class EdgeUndirectedTest extends EdgeBaseTest
 {

--- a/tests/Set/EdgesTest.php
+++ b/tests/Set/EdgesTest.php
@@ -2,7 +2,7 @@
 
 namespace Graphp\Graph\Tests\Set;
 
-use Graphp\Graph\Edge\Base as Edge;
+use Graphp\Graph\Edge;
 use Graphp\Graph\Graph;
 use Graphp\Graph\Set\Edges;
 use Graphp\Graph\Tests\TestCase;
@@ -156,7 +156,7 @@ class EdgesTest extends TestCase
     {
         $edgeRandom = $edges->getEdgeOrder(Edges::ORDER_RANDOM);
 
-        $this->assertInstanceOf('Graphp\Graph\Edge\Base', $edgeRandom);
+        $this->assertInstanceOf('Graphp\Graph\Edge', $edgeRandom);
         $edges->getEdgeIndex($edges->getIndexEdge($edgeRandom));
 
         $edgesRandom = $edges->getEdgesOrder(Edges::ORDER_RANDOM);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,8 @@
 
 namespace Graphp\Graph\Tests;
 
-use Graphp\Graph\Edge\Directed;
-use Graphp\Graph\Edge\Base as Edge;
+use Graphp\Graph\Edge;
+use Graphp\Graph\EdgeDirected;
 use Graphp\Graph\Graph;
 use Graphp\Graph\Vertex;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -81,7 +81,7 @@ class TestCase extends BaseTestCase
     private function getEdgeDump(Edge $edge)
     {
         $ret = get_class($edge) . ' ';
-        if ($edge instanceof Directed) {
+        if ($edge instanceof EdgeDirected) {
             $ret .= $edge->getVertexStart()->getId() . ' -> ' . $edge->getVertexEnd()->getId();
         } else {
             $vertices = $edge->getVertices()->getIds();


### PR DESCRIPTION
The new API is now much more consistent and explicit:

```php
// old
assert($v1->createEdge($v2) instanceof Graphp\Graph\Edge\Undirected);
assert($v1->createEdgeTo($v2) instanceof Graphp\Graph\Edge\Directed);
assert($edge instanceof Graphp\Graph\Edge\Base);

// new
assert($graph->createEdgeUndirected($v1, $v2) instanceof Graphp\Graph\EdgeUndirected);
assert($graph->createEdgeDirected($v1, $v2) instanceof Graphp\Graph\EdgeDirected);
assert($edge instanceof Graphp\Graph\Edge);
```

Builds on top of #175 and #166