### PR TITLE
Support ordering vertices and edges by custom callbacks, remove all `ORDER_*` consts

### DIFF
--- a/src/Walk.php
+++ b/src/Walk.php
@@ -42,11 +42,11 @@ class Walk implements DualAggregate
     /**
      * create new walk instance between given set of Vertices / array of Vertex instances
      *
-     * @param  Vertices|Vertex[]  $vertices
-     * @param  null|string|null   $orderBy
-     * @param  bool               $desc
+     * @param  Vertices|Vertex[]                 $vertices
+     * @param  null|string|callable(Edge):number $orderBy
+     * @param  bool                              $desc
      * @return Walk
-     * @throws UnderflowException if no vertices were given
+     * @throws UnderflowException                if no vertices were given
      * @see Edges::getEdgeOrder() for parameters $by and $desc
      */
     public static function factoryFromVertices($vertices, $orderBy = null, $desc = false)
@@ -76,10 +76,10 @@ class Walk implements DualAggregate
     /**
      * create new cycle instance from given predecessor map
      *
-     * @param  Vertex[]           $predecessors map of vid => predecessor vertex instance
-     * @param  Vertex             $vertex       start vertex to search predecessors from
-     * @param  null|string|int    $orderBy
-     * @param  bool               $desc
+     * @param  Vertex[]                          $predecessors map of vid => predecessor vertex instance
+     * @param  Vertex                            $vertex       start vertex to search predecessors from
+     * @param  null|string|callable(Edge):number $orderBy
+     * @param  bool                              $desc
      * @return Walk
      * @throws UnderflowException
      * @see Edges::getEdgeOrder() for parameters $by and $desc
@@ -127,11 +127,11 @@ class Walk implements DualAggregate
     /**
      * create new cycle instance with edges between given vertices
      *
-     * @param  Vertex[]|Vertices  $vertices
-     * @param  null|string|int    $orderBy
-     * @param  bool               $desc
+     * @param  Vertex[]|Vertices                 $vertices
+     * @param  null|string|callable(Edge):number $orderBy
+     * @param  bool                              $desc
      * @return Walk
-     * @throws UnderflowException if no vertices were given
+     * @throws UnderflowException                if no vertices were given
      * @see Edges::getEdgeOrder() for parameters $by and $desc
      * @uses self::factoryFromVertices()
      */

--- a/tests/Set/BaseVerticesTest.php
+++ b/tests/Set/BaseVerticesTest.php
@@ -40,7 +40,9 @@ abstract class BaseVerticesTest extends TestCase
         $this->assertEquals(array(), $vertices->getVector());
         $this->assertTrue($vertices->isEmpty());
         $this->assertTrue($vertices->getVertices()->isEmpty());
-        $this->assertTrue($vertices->getVerticesOrder(Vertices::ORDER_ID)->isEmpty());
+        $this->assertTrue($vertices->getVerticesOrder(function (Vertex $vertex) {
+            return $vertex->getId();
+        })->isEmpty());
         $this->assertTrue($vertices->getVerticesOrder('id')->isEmpty());
         $this->assertTrue($vertices->getVerticesDistinct()->isEmpty());
         $this->assertTrue($vertices->getVerticesMatch(function() { })->isEmpty());
@@ -90,7 +92,7 @@ abstract class BaseVerticesTest extends TestCase
      */
     public function testEmptyDoesNotHaveOrdered(Vertices $vertices)
     {
-        $vertices->getVertexOrder(Vertices::ORDER_ID);
+        $vertices->getVertexOrder('group');
     }
 
     public function testTwo()
@@ -227,14 +229,18 @@ abstract class BaseVerticesTest extends TestCase
         $biggest = $graph->createVertex()->setGroup(200);
 
         $vertices = $graph->getVertices();
-        $verticesOrdered = $vertices->getVerticesOrder(Vertices::ORDER_GROUP);
+        $verticesOrdered = $vertices->getVerticesOrder(function (Vertex $vertex) {
+            return $vertex->getGroup();
+        });
 
         $this->assertInstanceOf('Graphp\Graph\Set\Vertices', $verticesOrdered);
         $this->assertEquals(1, $verticesOrdered->getVertexFirst()->getGroup());
         $this->assertEquals(200, $verticesOrdered->getVertexLast()->getGroup());
 
         $this->assertSame($biggest, $verticesOrdered->getVertexLast());
-        $this->assertSame($biggest, $vertices->getVertexOrder(Vertices::ORDER_GROUP, true));
+        $this->assertSame($biggest, $vertices->getVertexOrder(function (Vertex $vertex) {
+            return $vertex->getGroup();
+        }, true));
 
         $sumgroups = function(Vertex $vertex) {
             return $vertex->getGroup();

--- a/tests/Set/EdgesTest.php
+++ b/tests/Set/EdgesTest.php
@@ -12,7 +12,7 @@ class EdgesTest extends TestCase
     /**
      *
      * @param array $edges
-     * @return Edges;
+     * @return Edges
      */
     protected function createEdges(array $edges)
     {
@@ -43,7 +43,9 @@ class EdgesTest extends TestCase
         $this->assertEquals(array(), $edges->getVector());
         $this->assertTrue($edges->isEmpty());
         $this->assertTrue($edges->getEdges()->isEmpty());
-        $this->assertTrue($edges->getEdgesOrder(Edges::ORDER_WEIGHT)->isEmpty());
+        $this->assertTrue($edges->getEdgesOrder(function (Edge $edge) {
+            return $edge->getWeight();
+        })->isEmpty());
         $this->assertTrue($edges->getEdgesOrder('weight')->isEmpty());
         $this->assertTrue($edges->getEdgesDistinct()->isEmpty());
         $this->assertTrue($edges->getEdgesMatch(function() { })->isEmpty());
@@ -92,7 +94,7 @@ class EdgesTest extends TestCase
      */
     public function testEmptyDoesNotHaveOrdered(Edges $edges)
     {
-        $edges->getEdgeOrder(Edges::ORDER_WEIGHT);
+        $edges->getEdgeOrder('weight');
     }
 
     public function testTwo()
@@ -244,31 +246,6 @@ class EdgesTest extends TestCase
         return false;
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetEdgeOrderInvalidSortBy()
-    {
-        // 1 -> 1
-        $graph = new Graph();
-        $v1 = $graph->createVertex(1);
-        $graph->createEdgeDirected($v1, $v1);
-
-        $edges = $graph->getEdges();
-
-        $edges->getEdgeOrder(-2);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetEdgesOrderInvalidSortBy()
-    {
-        $edges = $this->createEdges(array());
-
-        $edges->getEdgesOrder(-2);
-    }
-
     public function testOrderByGroup()
     {
         $graph = new Graph();
@@ -283,14 +260,18 @@ class EdgesTest extends TestCase
         $biggest = $graph->createEdgeUndirected($v1, $v2)->setWeight(200);
 
         $edges = $graph->getEdges();
-        $edgesOrdered = $edges->getEdgesOrder(Edges::ORDER_WEIGHT);
+        $edgesOrdered = $edges->getEdgesOrder(function (Edge $edge) {
+            return $edge->getWeight();
+        });
 
         $this->assertInstanceOf('Graphp\Graph\Set\Edges', $edgesOrdered);
         $this->assertEquals(1, $edgesOrdered->getEdgeFirst()->getWeight());
         $this->assertEquals(200, $edgesOrdered->getEdgeLast()->getWeight());
 
         $this->assertSame($biggest, $edgesOrdered->getEdgeLast());
-        $this->assertSame($biggest, $edges->getEdgeOrder(Edges::ORDER_WEIGHT, true));
+        $this->assertSame($biggest, $edges->getEdgeOrder(function (Edge $edge) {
+            return $edge->getWeight();
+        }, true));
 
         $sumweights = function(Edge $edge) {
             return $edge->getWeight();

--- a/tests/Set/VerticesTest.php
+++ b/tests/Set/VerticesTest.php
@@ -20,29 +20,6 @@ class VerticesTest extends BaseVerticesTest
         $this->assertTrue($vertices->isEmpty());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetVertexOrderInvalidSortBy()
-    {
-        $graph = new Graph();
-        $graph->createVertex(1);
-
-        $vertices = $graph->getVertices();
-
-        $vertices->getVertexOrder(-1);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testGetVicesOrderInvalidSortBy()
-    {
-        $vertices = $this->createVertices(array());
-
-        $vertices->getVerticesOrder(-1);
-    }
-
     public function testDuplicates()
     {
         $graph = new Graph();

--- a/tests/WalkTest.php
+++ b/tests/WalkTest.php
@@ -3,8 +3,7 @@
 namespace Graphp\Graph\Tests;
 
 use Graphp\Graph\Graph;
-use Graphp\Graph\Set\Edges;
-use Graphp\Graph\Vertex;
+use Graphp\Graph\Edge;
 use Graphp\Graph\Walk;
 
 class WalkTest extends TestCase
@@ -252,7 +251,9 @@ class WalkTest extends TestCase
         $walk = Walk::factoryFromVertices(array($v1, $v2));
 
         // edge with weight 10
-        $walk = Walk::factoryFromVertices(array($v1, $v2), Edges::ORDER_WEIGHT);
+        $walk = Walk::factoryFromVertices(array($v1, $v2), function (Edge $edge) {
+            return $edge->getWeight();
+        });
         $this->assertSame($e1, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 10
@@ -260,7 +261,9 @@ class WalkTest extends TestCase
         $this->assertSame($e1, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 20
-        $walk = Walk::factoryFromVertices(array($v1, $v2), Edges::ORDER_WEIGHT, true);
+        $walk = Walk::factoryFromVertices(array($v1, $v2), function (Edge $edge) {
+            return $edge->getWeight();
+        }, true);
         $this->assertSame($e2, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 20


### PR DESCRIPTION
```php
// old
$vertices->getVerticesOrder(Vertices::ORDER_ID);

// new
$vertices->getVerticesOrder(function (Vertex $vertex) {
    return $vertex->getId();
});
```

Among others, this is done in preparation for #114. Builds on top of #180 and #179.