### PR TITLE
Simplify Vertices and Edges collections, remove unneeded factory methods and favor collections over simple arrays

### DIFF
--- a/src/Graph.php
+++ b/src/Graph.php
@@ -3,26 +3,20 @@
 namespace Graphp\Graph;
 
 use Graphp\Graph\Exception\InvalidArgumentException;
-use Graphp\Graph\Exception\OutOfBoundsException;
 use Graphp\Graph\Set\DualAggregate;
 use Graphp\Graph\Set\Edges;
 use Graphp\Graph\Set\Vertices;
 
 class Graph extends Entity implements DualAggregate
 {
-    protected $verticesStorage = array();
-    protected $vertices;
-
-    protected $edgesStorage = array();
-    protected $edges;
+    protected $vertices = array();
+    protected $edges = array();
 
     /**
      * @param array $attributes
      */
     public function __construct(array $attributes = array())
     {
-        $this->vertices = Vertices::factoryArrayReference($this->verticesStorage);
-        $this->edges = Edges::factoryArrayReference($this->edgesStorage);
         $this->attributes = $attributes;
     }
 
@@ -33,7 +27,7 @@ class Graph extends Entity implements DualAggregate
      */
     public function getVertices()
     {
-        return $this->vertices;
+        return new Vertices($this->vertices);
     }
 
     /**
@@ -43,7 +37,7 @@ class Graph extends Entity implements DualAggregate
      */
     public function getEdges()
     {
-        return $this->edges;
+        return new Edges($this->edges);
     }
 
     /**
@@ -103,7 +97,7 @@ class Graph extends Entity implements DualAggregate
      */
     public function addVertex(Vertex $vertex)
     {
-        $this->verticesStorage[] = $vertex;
+        $this->vertices[] = $vertex;
     }
 
     /**
@@ -116,7 +110,7 @@ class Graph extends Entity implements DualAggregate
      */
     public function addEdge(Edge $edge)
     {
-        $this->edgesStorage []= $edge;
+        $this->edges []= $edge;
     }
 
     /**
@@ -130,12 +124,12 @@ class Graph extends Entity implements DualAggregate
      */
     public function removeEdge(Edge $edge)
     {
-        try {
-            unset($this->edgesStorage[$this->edges->getIndexEdge($edge)]);
-        }
-        catch (OutOfBoundsException $e) {
+        $key = \array_search($edge, $this->edges, true);
+        if ($key === false) {
             throw new InvalidArgumentException('Invalid Edge does not exist in this Graph');
         }
+
+        unset($this->edges[$key]);
     }
 
     /**
@@ -149,12 +143,12 @@ class Graph extends Entity implements DualAggregate
      */
     public function removeVertex(Vertex $vertex)
     {
-        try {
-            unset($this->verticesStorage[$this->vertices->getIndexVertex($vertex)]);
-        }
-        catch (OutOfBoundsException $e) {
+        $key = \array_search($vertex, $this->vertices, true);
+        if ($key === false) {
             throw new InvalidArgumentException('Invalid Vertex does not exist in this Graph');
         }
+
+        unset($this->vertices[$key]);
     }
 
     /**
@@ -162,13 +156,11 @@ class Graph extends Entity implements DualAggregate
      */
     public function __clone()
     {
-        $vertices = $this->verticesStorage;
-        $this->verticesStorage = array();
-        $this->vertices = Vertices::factoryArrayReference($this->verticesStorage);
+        $vertices = $this->vertices;
+        $this->vertices = array();
 
-        $edges = $this->edgesStorage;
-        $this->edgesStorage = array();
-        $this->edges = Edges::factoryArrayReference($this->edgesStorage);
+        $edges = $this->edges;
+        $this->edges = array();
 
         $map = array();
         foreach ($vertices as $originalVertex) {

--- a/src/Set/Edges.php
+++ b/src/Set/Edges.php
@@ -43,7 +43,7 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
     /**
      * instantiate new Set of Edges
      *
-     * @param array $edges
+     * @param Edge[] $edges
      */
     public function __construct(array $edges = array())
     {
@@ -307,12 +307,12 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
      * Duplicate Edge instances will be kept if the corresponding number of
      * Edge instances is also found in $otherEdges.
      *
-     * @param Edges|Edge[] $otherEdges
+     * @param Edges $otherEdges
      * @return Edges a new Edges set
      */
-    public function getEdgesIntersection($otherEdges)
+    public function getEdgesIntersection(Edges $otherEdges)
     {
-        $otherArray = self::factory($otherEdges)->getVector();
+        $otherArray = \iterator_to_array($otherEdges, false);
 
         $edges = array();
         foreach ($this->edges as $eid => $edge) {

--- a/src/Set/Edges.php
+++ b/src/Set/Edges.php
@@ -20,27 +20,6 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
     protected $edges = array();
 
     /**
-     * create new Edges instance
-     *
-     * You can pass in just about anything that can be expressed as a Set of
-     * Edges, such as:
-     * - an array of Edge instances
-     * - any Algorithm that implements the EdgesAggregate interface
-     * - a Graph instance or
-     * - an existing Set of Edges which will be returned as-is
-     *
-     * @param array|Edges|EdgesAggregate $edges
-     * @return Edges
-     */
-    public static function factory($edges)
-    {
-        if ($edges instanceof EdgesAggregate) {
-            return $edges->getEdges();
-        }
-        return new self($edges);
-    }
-
-    /**
      * instantiate new Set of Edges
      *
      * @param Edge[] $edges
@@ -271,7 +250,6 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
      * return self reference to Set of Edges
      *
      * @return Edges
-     * @see self::factory()
      */
     public function getEdges()
     {

--- a/src/Set/Edges.php
+++ b/src/Set/Edges.php
@@ -41,23 +41,6 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
     }
 
     /**
-     * create new Edges instance that references the given source array of Edge instances
-     *
-     * Any changes in the referenced source array will automatically be
-     * reflected in this Set of Edges, e.g. if you add an Edge instance to the
-     * array, it will automatically be included in this Set.
-     *
-     * @param array $edgesArray
-     * @return Edges
-     */
-    public static function factoryArrayReference(array &$edgesArray)
-    {
-        $edges = new static();
-        $edges->edges =& $edgesArray;
-        return $edges;
-    }
-
-    /**
      * instantiate new Set of Edges
      *
      * @param array $edges

--- a/src/Set/Vertices.php
+++ b/src/Set/Vertices.php
@@ -20,27 +20,6 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
     protected $vertices = array();
 
     /**
-     * create new Vertices instance
-     *
-     * You can pass in just about anything that can be expressed as a Set of
-     * Vertices, such as:
-     * - an array of Vertex instances
-     * - any Algorithm that implements the VerticesAggregate interface
-     * - a Graph instance or
-     * - an existing Set of Vertices which will be returned as-is
-     *
-     * @param array|Vertices|VerticesAggregate $vertices
-     * @return Vertices
-     */
-    public static function factory($vertices)
-    {
-        if ($vertices instanceof VerticesAggregate) {
-            return $vertices->getVertices();
-        }
-        return new self($vertices);
-    }
-
-    /**
      * instantiate new Set of Vertices
      *
      * @param Vertex[] $vertices
@@ -296,7 +275,6 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
      * return self reference to Set of Vertices
      *
      * @return Vertices
-     * @see self::factory()
      */
     public function getVertices()
     {

--- a/src/Set/Vertices.php
+++ b/src/Set/Vertices.php
@@ -43,7 +43,7 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
     /**
      * instantiate new Set of Vertices
      *
-     * @param array $vertices
+     * @param Vertex[] $vertices
      */
     public function __construct(array $vertices = array())
     {
@@ -239,12 +239,12 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
      * Duplicate Vertex instances will be kept if the corresponding number of
      * Vertex instances is also found in $otherVertices.
      *
-     * @param Vertices|Vertex[] $otherVertices
+     * @param Vertices $otherVertices
      * @return Vertices a new Vertices set
      */
-    public function getVerticesIntersection($otherVertices)
+    public function getVerticesIntersection(Vertices $otherVertices)
     {
-        $otherArray = self::factory($otherVertices)->getVector();
+        $otherArray = \iterator_to_array($otherVertices, false);
 
         $vertices = array();
         foreach ($this->vertices as $vid => $vertex) {

--- a/src/Set/Vertices.php
+++ b/src/Set/Vertices.php
@@ -41,23 +41,6 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
     }
 
     /**
-     * create new Vertices instance that references the given source array of Vertex instances
-     *
-     * Any changes in the referenced source array will automatically be
-     * reflected in this Set of Vertices, e.g. if you add a Vertex instance to
-     * the array, it will automatically be included in this Set.
-     *
-     * @param array $verticesArray
-     * @return Vertices
-     */
-    public static function factoryArrayReference(array &$verticesArray)
-    {
-        $vertices = new static();
-        $vertices->vertices =& $verticesArray;
-        return $vertices;
-    }
-
-    /**
      * instantiate new Set of Vertices
      *
      * @param array $vertices

--- a/src/Walk.php
+++ b/src/Walk.php
@@ -23,11 +23,11 @@ class Walk implements DualAggregate
     /**
      * construct new walk from given start vertex and given array of edges
      *
-     * @param  Edges|Edge[]         $edges
-     * @param  Vertex               $startVertex
+     * @param  Edges  $edges
+     * @param  Vertex $startVertex
      * @return Walk
      */
-    public static function factoryFromEdges($edges, Vertex $startVertex)
+    public static function factoryFromEdges(Edges $edges, Vertex $startVertex)
     {
         $vertices = array($startVertex);
         $vertexCurrent = $startVertex;
@@ -36,20 +36,20 @@ class Walk implements DualAggregate
             $vertices []= $vertexCurrent;
         }
 
-        return new self($vertices, $edges);
+        return new self(new Vertices($vertices), $edges);
     }
 
     /**
      * create new walk instance between given set of Vertices / array of Vertex instances
      *
-     * @param  Vertices|Vertex[]                 $vertices
+     * @param  Vertices                          $vertices
      * @param  null|string|callable(Edge):number $orderBy
      * @param  bool                              $desc
      * @return Walk
      * @throws UnderflowException                if no vertices were given
      * @see Edges::getEdgeOrder() for parameters $by and $desc
      */
-    public static function factoryFromVertices($vertices, $orderBy = null, $desc = false)
+    public static function factoryFromVertices(Vertices $vertices, $orderBy = null, $desc = false)
     {
         $edges = array();
         $last = NULL;
@@ -70,13 +70,13 @@ class Walk implements DualAggregate
             throw new UnderflowException('No vertices given');
         }
 
-        return new self($vertices, $edges);
+        return new self($vertices, new Edges($edges));
     }
 
     /**
      * create new cycle instance with edges between given vertices
      *
-     * @param  Vertex[]|Vertices                 $vertices
+     * @param  Vertices                          $vertices
      * @param  null|string|callable(Edge):number $orderBy
      * @param  bool                              $desc
      * @return Walk
@@ -84,7 +84,7 @@ class Walk implements DualAggregate
      * @see Edges::getEdgeOrder() for parameters $by and $desc
      * @uses self::factoryFromVertices()
      */
-    public static function factoryCycleFromVertices($vertices, $orderBy = null, $desc = false)
+    public static function factoryCycleFromVertices(Vertices $vertices, $orderBy = null, $desc = false)
     {
         $cycle = self::factoryFromVertices($vertices, $orderBy, $desc);
 
@@ -102,13 +102,13 @@ class Walk implements DualAggregate
     /**
      * create new cycle instance with vertices connected by given edges
      *
-     * @param  Edges|Edge[] $edges
-     * @param  Vertex       $startVertex
+     * @param  Edges  $edges
+     * @param  Vertex $startVertex
      * @return Walk
      * @throws InvalidArgumentException if the given array of edges does not represent a valid cycle
      * @uses self::factoryFromEdges()
      */
-    public static function factoryCycleFromEdges($edges, Vertex $startVertex)
+    public static function factoryCycleFromEdges(Edges $edges, Vertex $startVertex)
     {
         $cycle = self::factoryFromEdges($edges, $startVertex);
 
@@ -121,21 +121,19 @@ class Walk implements DualAggregate
     }
 
     /**
-     *
      * @var Vertices
      */
     protected $vertices;
 
     /**
-     *
      * @var Edges
      */
     protected $edges;
 
-    protected function __construct($vertices, $edges)
+    protected function __construct(Vertices $vertices, Edges $edges)
     {
-        $this->vertices = Vertices::factory($vertices);
-        $this->edges    = Edges::factory($edges);
+        $this->vertices = $vertices;
+        $this->edges = $edges;
     }
 
     /**
@@ -148,7 +146,7 @@ class Walk implements DualAggregate
      */
     public function getGraph()
     {
-        return $this->getVertices()->getVertexFirst()->getGraph();
+        return $this->vertices->getVertexFirst()->getGraph();
     }
 
     /**

--- a/tests/Set/EdgesTest.php
+++ b/tests/Set/EdgesTest.php
@@ -15,22 +15,7 @@ class EdgesTest extends TestCase
      */
     protected function createEdges(array $edges)
     {
-        return Edges::factory($edges);
-    }
-
-    public function testFactory()
-    {
-        // 1 -> 1
-        $graph = new Graph();
-        $v1 = $graph->createVertex();
-        $e1 = $graph->createEdgeDirected($v1, $v1);
-
-        $edgesFromArray = $this->createEdges(array($e1));
-        $this->assertInstanceOf('Graphp\Graph\Set\Edges', $edgesFromArray);
-        $this->assertSame($e1, $edgesFromArray->getEdgeFirst());
-
-        $edgesFromEdges = Edges::factory($edgesFromArray);
-        $this->assertSame($edgesFromArray, $edgesFromEdges);
+        return new Edges($edges);
     }
 
     public function testEmpty()

--- a/tests/Set/VerticesTest.php
+++ b/tests/Set/VerticesTest.php
@@ -14,19 +14,6 @@ class VerticesTest extends TestCase
         return new Vertices($vertices);
     }
 
-    public function testFactory()
-    {
-        $graph = new Graph();
-        $vertex = $graph->createVertex();
-
-        $verticesFromArray = $this->createVertices(array($vertex));
-        $this->assertInstanceOf('Graphp\Graph\Set\Vertices', $verticesFromArray);
-        $this->assertSame($vertex, $verticesFromArray->getVertexFirst());
-
-        $verticesFromVertices = Vertices::factory($verticesFromArray);
-        $this->assertSame($verticesFromArray, $verticesFromVertices);
-    }
-
     public function testEmpty()
     {
         $vertices = $this->createVertices(array());
@@ -292,14 +279,6 @@ class VerticesTest extends TestCase
     {
         $verticesIntersection = $verticesTwo->getVerticesIntersection($verticesEmpty);
         $this->assertCount(0, $verticesIntersection);
-    }
-
-    public function testFactoryEmptyArray()
-    {
-        $vertices = Vertices::factory(array());
-
-        $this->assertInstanceOf('Graphp\Graph\Set\Vertices', $vertices);
-        $this->assertTrue($vertices->isEmpty());
     }
 
     public function testDuplicates()

--- a/tests/WalkTest.php
+++ b/tests/WalkTest.php
@@ -2,8 +2,10 @@
 
 namespace Graphp\Graph\Tests;
 
-use Graphp\Graph\Graph;
 use Graphp\Graph\Edge;
+use Graphp\Graph\Graph;
+use Graphp\Graph\Set\Edges;
+use Graphp\Graph\Set\Vertices;
 use Graphp\Graph\Walk;
 
 class WalkTest extends TestCase
@@ -13,7 +15,7 @@ class WalkTest extends TestCase
      */
     public function testWalkCanNotBeEmpty()
     {
-        Walk::factoryCycleFromVertices(array());
+        Walk::factoryCycleFromVertices(new Vertices(array()));
     }
 
     public function testWalkPath()
@@ -26,7 +28,7 @@ class WalkTest extends TestCase
         $e1 = $graph->createEdgeDirected($v1, $v2);
         $e2 = $graph->createEdgeDirected($v2, $v3);
 
-        $walk = Walk::factoryFromEdges(array($e1, $e2), $v1);
+        $walk = Walk::factoryFromEdges(new Edges(array($e1, $e2)), $v1);
 
         $this->assertEquals(3, count($walk->getVertices()));
         $this->assertEquals(2, count($walk->getEdges()));
@@ -61,7 +63,7 @@ class WalkTest extends TestCase
         $graph->createEdgeDirected($v2, $v3);
 
         // construct partial walk "1 -- 2"
-        $walk = Walk::factoryFromEdges(array($e1), $v1);
+        $walk = Walk::factoryFromEdges(new Edges(array($e1)), $v1);
 
         $this->assertEquals(2, count($walk->getVertices()));
         $this->assertEquals(1, count($walk->getEdges()));
@@ -71,7 +73,7 @@ class WalkTest extends TestCase
         $this->assertTrue($walk->isValid());
 
         // construct same partial walk "1 -- 2"
-        $walkVertices = Walk::factoryFromVertices(array($v1, $v2));
+        $walkVertices = Walk::factoryFromVertices(new Vertices(array($v1, $v2)));
 
         $this->assertEquals(2, count($walkVertices->getVertices()));
         $this->assertEquals(1, count($walkVertices->getEdges()));
@@ -86,7 +88,7 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex();
         $e1 = $graph->createEdgeUndirected($v1, $v1);
 
-        $walk = Walk::factoryFromEdges(array($e1), $v1);
+        $walk = Walk::factoryFromEdges(new Edges(array($e1)), $v1);
 
         $this->assertEquals(2, count($walk->getVertices()));
         $this->assertEquals(1, count($walk->getEdges()));
@@ -119,7 +121,7 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex();
         $e1 = $graph->createEdgeUndirected($v1, $v1);
 
-        $walk = Walk::factoryCycleFromEdges(array($e1), $v1);
+        $walk = Walk::factoryCycleFromEdges(new Edges(array($e1)), $v1);
 
         $this->assertEquals(2, count($walk->getVertices()));
         $this->assertEquals(1, count($walk->getEdges()));
@@ -141,7 +143,7 @@ class WalkTest extends TestCase
         $graph->createEdgeUndirected($v2, $v1);
 
         // should actually be [v1, v2, v1]
-        Walk::factoryCycleFromVertices(array($v1, $v2));
+        Walk::factoryCycleFromVertices(new Vertices(array($v1, $v2)));
     }
 
     /**
@@ -155,7 +157,7 @@ class WalkTest extends TestCase
         $v2 = $graph->createVertex();
         $e1 = $graph->createEdgeUndirected($v1, $v2);
 
-        Walk::factoryCycleFromEdges(array($e1), $v1);
+        Walk::factoryCycleFromEdges(new Edges(array($e1)), $v1);
     }
 
     public function testFactoryCycleFromEdgesWithLoopCycle()
@@ -167,7 +169,7 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex();
         $e1 = $graph->createEdgeDirected($v1, $v1);
 
-        $cycle = Walk::factoryCycleFromEdges(array($e1), $v1);
+        $cycle = Walk::factoryCycleFromEdges(new Edges(array($e1)), $v1);
 
         $this->assertCount(2, $cycle->getVertices());
         $this->assertCount(1, $cycle->getEdges());
@@ -185,7 +187,7 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex();
         $graph->createEdgeDirected($v1, $v1);
 
-        $cycle = Walk::factoryCycleFromVertices(array($v1, $v1));
+        $cycle = Walk::factoryCycleFromVertices(new Vertices(array($v1, $v1)));
 
         $this->assertCount(2, $cycle->getVertices());
         $this->assertCount(1, $cycle->getEdges());
@@ -204,7 +206,7 @@ class WalkTest extends TestCase
         $v1 = $graph->createVertex();
 
         // should actually be [v1, v1]
-        Walk::factoryCycleFromVertices(array($v1));
+        Walk::factoryCycleFromVertices(new Vertices(array($v1)));
     }
 
     public function testFactoryFromVertices()
@@ -219,26 +221,26 @@ class WalkTest extends TestCase
         $e2 = $graph->createEdgeUndirected($v1, $v2)->setAttribute('weight', 20);
 
         // any edge in walk
-        $walk = Walk::factoryFromVertices(array($v1, $v2));
+        $walk = Walk::factoryFromVertices(new Vertices(array($v1, $v2)));
 
         // edge with weight 10
-        $walk = Walk::factoryFromVertices(array($v1, $v2), function (Edge $edge) {
+        $walk = Walk::factoryFromVertices(new Vertices(array($v1, $v2)), function (Edge $edge) {
             return $edge->getAttribute('weight');
         });
         $this->assertSame($e1, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 10
-        $walk = Walk::factoryFromVertices(array($v1, $v2), 'weight');
+        $walk = Walk::factoryFromVertices(new Vertices(array($v1, $v2)), 'weight');
         $this->assertSame($e1, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 20
-        $walk = Walk::factoryFromVertices(array($v1, $v2), function (Edge $edge) {
+        $walk = Walk::factoryFromVertices(new Vertices(array($v1, $v2)), function (Edge $edge) {
             return $edge->getAttribute('weight');
         }, true);
         $this->assertSame($e2, $walk->getEdges()->getEdgeFirst());
 
         // edge with weight 20
-        $walk = Walk::factoryFromVertices(array($v1, $v2), 'weight', true);
+        $walk = Walk::factoryFromVertices(new Vertices(array($v1, $v2)), 'weight', true);
         $this->assertSame($e2, $walk->getEdges()->getEdgeFirst());
     }
 }


### PR DESCRIPTION
```php
// old
$vertices = Vertices::factory($arrayOfVertices);
$vertices->getVerticesIntersection($arrayOfVertices);

// new (already supported before)
$vertices = new Vertices($arrayOfVertices);
$vertices->getVerticesIntersection(new Vertices($arrayOfVertices));
```