### PR TITLE
Add Graph::withoutVertex() and Graph::withoutEdge() instead of destroy()

### DIFF
--- a/src/Edge.php
+++ b/src/Edge.php
@@ -107,21 +107,6 @@ abstract class Edge extends Entity implements VerticesAggregate
     }
 
     /**
-     * destroy edge and remove reference from vertices and graph
-     *
-     * @uses Graph::removeEdge()
-     * @uses Vertex::removeEdge()
-     * @return void
-     */
-    public function destroy()
-    {
-        $this->getGraph()->removeEdge($this);
-        foreach ($this->getVertices() as $vertex) {
-            $vertex->removeEdge($this);
-        }
-    }
-
-    /**
      * do NOT allow cloning of objects
      *
      * @throws BadMethodCallException

--- a/src/Graph.php
+++ b/src/Graph.php
@@ -88,6 +88,105 @@ class Graph extends Entity implements DualAggregate
     }
 
     /**
+     * Returns a copy of this graph without the given vertex
+     *
+     * If this vertex was not found in this graph, the returned graph will be
+     * identical.
+     *
+     * @param Vertex $vertex
+     * @return self
+     */
+    public function withoutVertex(Vertex $vertex)
+    {
+        return $this->withoutVertices(new Vertices(array($vertex)));
+    }
+
+    /**
+     * Returns a copy of this graph without the given vertices
+     *
+     * If any of the given vertices can not be found in this graph, they will
+     * silently be ignored. If neither of the vertices can be found in this graph,
+     * the returned graph will be identical.
+     *
+     * @param Vertices $vertices
+     * @return self
+     */
+    public function withoutVertices(Vertices $vertices)
+    {
+        // keep copy of original vertices and edges and temporarily remove all $vertices and their adjacent edges
+        $originalEdges = $this->edges;
+        $originalVertices = $this->vertices;
+        foreach ($vertices as $vertex) {
+            if (($key = \array_search($vertex, $this->vertices, true)) !== false) {
+                unset($this->vertices[$key]);
+                foreach ($vertex->getEdges() as $edge) {
+                    if (($key = \array_search($edge, $this->edges, true)) !== false) {
+                        unset($this->edges[$key]);
+                    }
+                }
+            }
+        }
+
+        // no vertices matched => return graph as-is
+        if (\count($this->vertices) === \count($originalVertices)) {
+            return $this;
+        }
+
+        // clone graph with vertices/edges temporarily removed, then restore
+        $clone = clone $this;
+        $this->edges= $originalEdges;
+        $this->vertices = $originalVertices;
+
+        return $clone;
+    }
+
+    /**
+     * Returns a copy of this graph without the given edge
+     *
+     * If this edge was not found in this graph, the returned graph will be
+     * identical.
+     *
+     * @param Edge $edge
+     * @return self
+     */
+    public function withoutEdge(Edge $edge)
+    {
+        return $this->withoutEdges(new Edges(array($edge)));
+    }
+
+    /**
+     * Returns a copy of this graph without the given edges
+     *
+     * If any of the given edges can not be found in this graph, they will
+     * silently be ignored. If neither of the edges can be found in this graph,
+     * the returned graph will be identical.
+     *
+     * @param Edges $edges
+     * @return self
+     */
+    public function withoutEdges(Edges $edges)
+    {
+        // keep copy of original edges and temporarily remove all $edges
+        $original = $this->edges;
+        foreach ($edges as $edge) {
+            if (($key = \array_search($edge, $this->edges, true)) !== false) {
+                unset($this->edges[$key]);
+            }
+        }
+
+        // no edges matched => return graph as-is
+        if (\count($this->edges) === \count($original)) {
+            return $this;
+        }
+
+        // clone graph with edges temporarily removed, then restore
+        $clone = clone $this;
+        $this->edges = $original;
+
+        return $clone;
+    }
+
+    /**
      * adds a new Vertex to the Graph (MUST NOT be called manually!)
      *
      * @param  Vertex $vertex instance of the new Vertex
@@ -111,44 +210,6 @@ class Graph extends Entity implements DualAggregate
     public function addEdge(Edge $edge)
     {
         $this->edges []= $edge;
-    }
-
-    /**
-     * remove the given edge from list of connected edges (MUST NOT be called manually!)
-     *
-     * @param  Edge                     $edge
-     * @return void
-     * @throws InvalidArgumentException if given edge does not exist (should not ever happen)
-     * @internal
-     * @see Edge::destroy() instead!
-     */
-    public function removeEdge(Edge $edge)
-    {
-        $key = \array_search($edge, $this->edges, true);
-        if ($key === false) {
-            throw new InvalidArgumentException('Invalid Edge does not exist in this Graph');
-        }
-
-        unset($this->edges[$key]);
-    }
-
-    /**
-     * remove the given vertex from list of known vertices (MUST NOT be called manually!)
-     *
-     * @param  Vertex                   $vertex
-     * @return void
-     * @throws InvalidArgumentException if given vertex does not exist (should not ever happen)
-     * @internal
-     * @see Vertex::destroy() instead!
-     */
-    public function removeVertex(Vertex $vertex)
-    {
-        $key = \array_search($vertex, $this->vertices, true);
-        if ($key === false) {
-            throw new InvalidArgumentException('Invalid Vertex does not exist in this Graph');
-        }
-
-        unset($this->vertices[$key]);
     }
 
     /**

--- a/src/Vertex.php
+++ b/src/Vertex.php
@@ -3,7 +3,6 @@
 namespace Graphp\Graph;
 
 use Graphp\Graph\Exception\BadMethodCallException;
-use Graphp\Graph\Exception\InvalidArgumentException;
 use Graphp\Graph\Set\Edges;
 use Graphp\Graph\Set\EdgesAggregate;
 use Graphp\Graph\Set\Vertices;
@@ -56,24 +55,6 @@ class Vertex extends Entity implements EdgesAggregate
     public function addEdge(Edge $edge)
     {
         $this->edges[] = $edge;
-    }
-
-    /**
-     * remove the given edge from list of connected edges (MUST NOT be called manually)
-     *
-     * @param  Edge                     $edge
-     * @return void
-     * @throws InvalidArgumentException if given edge does not exist
-     * @internal
-     * @see Edge::destroy() instead!
-     */
-    public function removeEdge(Edge $edge)
-    {
-        $id = \array_search($edge, $this->edges, true);
-        if ($id === false) {
-            throw new InvalidArgumentException('Given edge does NOT exist');
-        }
-        unset($this->edges[$id]);
     }
 
     /**
@@ -254,20 +235,6 @@ class Vertex extends Entity implements EdgesAggregate
         }
 
         return new Vertices($ret);
-    }
-
-    /**
-     * destroy vertex and all edges connected to it and remove reference from graph
-     *
-     * @uses Edge::destroy()
-     * @uses Graph::removeVertex()
-     */
-    public function destroy()
-    {
-        foreach ($this->getEdges()->getEdgesDistinct() as $edge) {
-            $edge->destroy();
-        }
-        $this->graph->removeVertex($this);
     }
 
     /**

--- a/src/Walk.php
+++ b/src/Walk.php
@@ -200,33 +200,4 @@ class Walk implements DualAggregate
 
         return $ret;
     }
-
-    /**
-     * check to make sure this walk is still valid (i.e. source graph still contains all vertices and edges)
-     *
-     * @return bool
-     * @uses Walk::getGraph()
-     * @uses Graph::getVertices()
-     * @uses Graph::getEdges()
-     */
-    public function isValid()
-    {
-        $vertices = \iterator_to_array($this->getGraph()->getVertices(), false);
-
-        // check source graph contains all vertices
-        foreach ($this->getVertices() as $vertex) {
-            if (!\in_array($vertex, $vertices, true)) {
-                return false;
-            }
-        }
-        $edges = $this->getGraph()->getEdges()->getVector();
-        // check source graph contains all edges
-        foreach ($this->edges as $edge) {
-            if (!\in_array($edge, $edges, true)) {
-                return false;
-            }
-        }
-
-        return true;
-    }
 }

--- a/tests/EdgeTest.php
+++ b/tests/EdgeTest.php
@@ -104,18 +104,6 @@ abstract class EdgeTest extends EntityTest
         $this->assertSame($this->v1, $edge->getVertexToFrom($this->v1));
     }
 
-    public function testRemoveWithLoop()
-    {
-        $edge = $this->createEdgeLoop();
-
-        $this->assertEquals(array($this->edge, $edge), $this->graph->getEdges()->getVector());
-
-        $edge->destroy();
-
-        $this->assertEquals(array($this->edge), $this->graph->getEdges()->getVector());
-        $this->assertEquals(array($this->v1, $this->v2), $this->graph->getVertices()->getVector());
-    }
-
     protected function createEntity()
     {
         return $this->createEdge();

--- a/tests/VertexTest.php
+++ b/tests/VertexTest.php
@@ -123,44 +123,6 @@ class VertexTest extends EntityTest
         $this->graph->createEdgeDirected($this->vertex, $graphOther->createVertex());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testRemoveInvalidEdge()
-    {
-        // 2 -- 3
-        $v2 = $this->graph->createVertex();
-        $v3 = $this->graph->createVertex();
-        $edge = $this->graph->createEdgeUndirected($v2, $v3);
-
-        $this->vertex->removeEdge($edge);
-    }
-
-    public function testRemoveWithEdgeLoopUndirected()
-    {
-        // 1 -- 1
-        $this->graph->createEdgeUndirected($this->vertex, $this->vertex);
-
-        $this->assertEquals(array($this->vertex), $this->graph->getVertices()->getVector());
-
-        $this->vertex->destroy();
-
-        $this->assertEquals(array(), $this->graph->getVertices()->getVector());
-        $this->assertEquals(array(), $this->graph->getEdges()->getVector());
-    }
-
-    public function testRemoveWithEdgeLoopDirected()
-    {
-        // 1 --> 1
-        $this->graph->createEdgeDirected($this->vertex, $this->vertex);
-
-        $this->assertEquals(array($this->vertex), $this->graph->getVertices()->getVector());
-
-        $this->vertex->destroy();
-
-        $this->assertEquals(array(), $this->graph->getVertices()->getVector());
-        $this->assertEquals(array(), $this->graph->getEdges()->getVector());
-    }
 
     protected function createEntity()
     {

--- a/tests/WalkTest.php
+++ b/tests/WalkTest.php
@@ -30,26 +30,14 @@ class WalkTest extends TestCase
 
         $walk = Walk::factoryFromEdges(new Edges(array($e1, $e2)), $v1);
 
+        $this->assertSame($graph, $walk->getGraph());
         $this->assertEquals(3, count($walk->getVertices()));
         $this->assertEquals(2, count($walk->getEdges()));
         $this->assertSame($v1, $walk->getVertices()->getVertexFirst());
         $this->assertSame($v3, $walk->getVertices()->getVertexLast());
         $this->assertSame(array($v1, $e1, $v2, $e2, $v3), $walk->getAlternatingSequence());
-        $this->assertTrue($walk->isValid());
 
         return $walk;
-    }
-
-    /**
-     * @param Walk $walk
-     * @depends testWalkPath
-     */
-    public function testWalkPathInvalidateByDestroyingVertex(Walk $walk)
-    {
-        // delete v3
-        $walk->getVertices()->getVertexLast()->destroy();
-
-        $this->assertFalse($walk->isValid());
     }
 
     public function testWalkWithinGraph()
@@ -65,12 +53,12 @@ class WalkTest extends TestCase
         // construct partial walk "1 -- 2"
         $walk = Walk::factoryFromEdges(new Edges(array($e1)), $v1);
 
+        $this->assertSame($graph, $walk->getGraph());
         $this->assertEquals(2, count($walk->getVertices()));
         $this->assertEquals(1, count($walk->getEdges()));
         $this->assertSame($v1, $walk->getVertices()->getVertexFirst());
         $this->assertSame($v2, $walk->getVertices()->getVertexLast());
         $this->assertSame(array($v1, $e1, $v2), $walk->getAlternatingSequence());
-        $this->assertTrue($walk->isValid());
 
         // construct same partial walk "1 -- 2"
         $walkVertices = Walk::factoryFromVertices(new Vertices(array($v1, $v2)));
@@ -94,24 +82,8 @@ class WalkTest extends TestCase
         $this->assertEquals(1, count($walk->getEdges()));
         $this->assertSame($v1, $walk->getVertices()->getVertexFirst());
         $this->assertSame($v1, $walk->getVertices()->getVertexLast());
-        $this->assertTrue($walk->isValid());
 
         return $walk;
-    }
-
-    /**
-     * @param Walk $walk
-     * @depends testWalkLoop
-     */
-    public function testWalkInvalidByDestroyingEdge(Walk $walk)
-    {
-        // destroy first edge found
-        foreach ($walk->getEdges() as $edge) {
-            $edge->destroy();
-            break;
-        }
-
-        $this->assertFalse($walk->isValid());
     }
 
     public function testWalkLoopCycle()
@@ -127,7 +99,6 @@ class WalkTest extends TestCase
         $this->assertEquals(1, count($walk->getEdges()));
         $this->assertSame($v1, $walk->getVertices()->getVertexFirst());
         $this->assertSame($v1, $walk->getVertices()->getVertexLast());
-        $this->assertTrue($walk->isValid());
     }
 
     /**
@@ -175,7 +146,6 @@ class WalkTest extends TestCase
         $this->assertCount(1, $cycle->getEdges());
         $this->assertSame($v1, $cycle->getVertices()->getVertexFirst());
         $this->assertSame($v1, $cycle->getVertices()->getVertexLast());
-        $this->assertTrue($cycle->isValid());
     }
 
     public function testFactoryCycleFromVerticesWithLoopCycle()
@@ -193,7 +163,6 @@ class WalkTest extends TestCase
         $this->assertCount(1, $cycle->getEdges());
         $this->assertSame($v1, $cycle->getVertices()->getVertexFirst());
         $this->assertSame($v1, $cycle->getVertices()->getVertexLast());
-        $this->assertTrue($cycle->isValid());
     }
 
 


### PR DESCRIPTION
Destroying a Vertex or Edge will no longer leave an object in an invalid
state but will instead return a new graph without the given entity. Also
add Graph::withoutVertices() and Graph::withoutEdges() to remove
multiple entities at once.

Accordingly, Walk::isValid() has been removed as it would always return
true.

```php
// old
$vertex->destroy();
$edges->destroy();

// new
$graph = $graph->withoutVertex($vertex);
$graph = $graph->withoutEdge($edge);
```

Builds on top of #188