### PR TITLE
Remove left-over namespaced Exception interface

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace Graphp\Graph;
-
-interface Exception
-{
-}


### PR DESCRIPTION
Small left-over from #193, also remove the now unused namespaced `Exception` interface.