### PR TITLE
Run tests on PHP7.4, PHP8 and PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/examples/ export-ignore
+/phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
+/tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,5 @@ install:
   - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,26 @@
 language: php
 
-php:
-# - 5.3 # requires old distro, see below
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
-  - hhvm # ignore errors, see below
-
 # lock distro so future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+    - php: hhvm-3.18
   allow_failures:
-    - php: hhvm
-
-sudo: false
+    - php: hhvm-3.18
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
   - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ $ composer require clue/graph:^0.9.1
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 7+ and
+extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
 It's *highly recommended to use PHP 7+* for this project.
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.0 || ^5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "graphp/graphviz": "GraphViz graph drawing / DOT output",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": "^7.0 || ^5.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4 || ^5.7 || ^4.8.35"
+        "phpunit/phpunit": "^9.0 || ^5.7 || ^4.8.35"
     },
     "suggest": {
         "graphp/graphviz": "GraphViz graph drawing / DOT output",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^7.0 || ^5.3"
+        "php": ">=5.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php"
-         colors="true" convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
->
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
-        <testsuite name="Graph Test Suite">
+        <testsuite name="Graph test suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Graph test suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Exception/NegativeCycleException.php
+++ b/src/Exception/NegativeCycleException.php
@@ -14,8 +14,13 @@ class NegativeCycleException extends UnexpectedValueException implements Graph\E
      */
     private $cycle;
 
-    public function __construct($message, $code = NULL, $previous = NULL, Walk $cycle)
+    public function __construct($message, $code = NULL, $previous = NULL, Walk $cycle = null)
     {
+        // $cycle is required, but required argument may not appear after option arguments as of PHP 8
+        if ($cycle === null) {
+            throw new \InvalidArgumentException('Missing required cycle');
+        }
+
         parent::__construct($message, $code, $previous);
         $this->cycle = $cycle;
     }

--- a/tests/Edge/EdgeAttributesTest.php
+++ b/tests/Edge/EdgeAttributesTest.php
@@ -14,7 +14,10 @@ class EdgeAttributesTest extends TestCase
      */
     private $edge;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpGraph()
     {
 
         $graph = new Graph();
@@ -40,61 +43,49 @@ class EdgeAttributesTest extends TestCase
         $this->assertEquals(null, $this->edge->getCapacityRemaining());
     }
 
-    /**
-     * @expectedException RangeException
-     */
     public function testFlowMustNotExceedCapacity()
     {
         $this->edge->setCapacity(20);
+
+        $this->setExpectedException('RangeException');
         $this->edge->setFlow(100);
     }
 
-    /**
-     * @expectedException RangeException
-     */
     public function testCapacityMustBeGreaterThanFlow()
     {
         $this->edge->setFlow(100);
+
+        $this->setExpectedException('RangeException');
         $this->edge->setCapacity(20);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWeightMustBeNumeric()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->setWeight("10");
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCapacityMustBeNumeric()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->setCapacity("10");
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCapacityMustBePositive()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->setCapacity(-10);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFlowMustBeNumeric()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->setFlow("10");
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testFlowMustBePositive()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->setFlow(-10);
     }
 }

--- a/tests/Edge/EdgeBaseTest.php
+++ b/tests/Edge/EdgeBaseTest.php
@@ -25,7 +25,10 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
      */
     abstract protected function createEdgeLoop();
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpGraph()
     {
         $this->graph = new Graph();
         $this->v1 = $this->graph->createVertex(1);
@@ -53,21 +56,19 @@ abstract class EdgeBaseTest extends AbstractAttributeAwareTest
         $this->assertFalse($this->edge->hasVertexTarget($v3));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testEdgeFromInvalid()
     {
         $v3 = $this->graph->createVertex(3);
+
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->getVertexFromTo($v3);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testEdgeToInvalid()
     {
         $v3 = $this->graph->createVertex(3);
+
+        $this->setExpectedException('InvalidArgumentException');
         $this->edge->getVertexToFrom($v3);
     }
 

--- a/tests/Exception/NegativeCycleExceptionTest.php
+++ b/tests/Exception/NegativeCycleExceptionTest.php
@@ -18,4 +18,10 @@ class NegativeCycleExceptionTest extends TestCase
         $this->assertEquals('test', $exception->getMessage());
         $this->assertEquals($cycle, $exception->getCycle());
     }
+
+    public function testConstructorThrowsWhenNoCycleIsGiven()
+    {
+        $this->setExpectedException('InvalidArgumentException');
+        new NegativeCycleException('test');
+    }
 }

--- a/tests/GraphTest.php
+++ b/tests/GraphTest.php
@@ -9,7 +9,10 @@ use Fhaculty\Graph\Tests\Attribute\AbstractAttributeAwareTest;
 
 class GraphTest extends AbstractAttributeAwareTest
 {
-    public function setup()
+    /**
+     * @before
+     */
+    public function setUpGraph()
     {
         $this->graph = new Graph();
     }
@@ -27,13 +30,13 @@ class GraphTest extends AbstractAttributeAwareTest
 
     /**
      * test to make sure vertex can not be cloned into same graph (due to duplicate id)
-     *
-     * @expectedException RuntimeException
      */
     public function testInvalidVertexClone()
     {
         $graph = new Graph();
         $vertex = $graph->createVertex(123);
+
+        $this->setExpectedException('RuntimeException');
         $graph->createVertexClone($vertex);
     }
 
@@ -44,12 +47,11 @@ class GraphTest extends AbstractAttributeAwareTest
         $this->assertGraphEquals($graph, $newgraph);
     }
 
-    /**
-     * @expectedException OutOfBoundsException
-     */
     public function testGetVertexNonexistant()
     {
         $graph = new Graph();
+
+        $this->setExpectedException('OutOfBoundsException');
         $graph->getVertex('non-existant');
     }
 
@@ -106,21 +108,21 @@ class GraphTest extends AbstractAttributeAwareTest
 
     /**
      * fail to create two vertices with same ID
-     * @expectedException OverflowException
      */
     public function testFailDuplicateVertex()
     {
         $graph = new Graph();
         $graph->createVertex(33);
+
+        $this->setExpectedException('OverflowException');
         $graph->createVertex(33);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateInvalidId()
     {
         $graph = new Graph();
+
+        $this->setExpectedException('InvalidArgumentException');
         $graph->createVertex(array('invalid'));
     }
 
@@ -200,12 +202,13 @@ class GraphTest extends AbstractAttributeAwareTest
 
     /**
      * expect to fail for invalid number of vertices
-     * @expectedException InvalidArgumentException
      * @dataProvider createVerticesFailProvider
      */
     public function testCreateVerticesFail($number)
     {
         $graph = new Graph();
+
+        $this->setExpectedException('InvalidArgumentException');
         $graph->createVertices($number);
     }
 
@@ -262,12 +265,11 @@ class GraphTest extends AbstractAttributeAwareTest
         }
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateVerticesContainsInvalid()
     {
         $graph = new Graph();
+
+        $this->setExpectedException('InvalidArgumentException');
         $graph->createVertices(array(1, 2, array(), 3));
     }
 
@@ -291,7 +293,6 @@ class GraphTest extends AbstractAttributeAwareTest
 
     /**
      * @param Graph $graph
-     * @expectedException InvalidArgumentException
      * @depends testRemoveEdge
      */
     public function testRemoveEdgeInvalid(Graph $graph)
@@ -299,6 +300,8 @@ class GraphTest extends AbstractAttributeAwareTest
         $edge = $graph->getVertex(1)->createEdge($graph->getVertex(2));
 
         $edge->destroy();
+
+        $this->setExpectedException('InvalidArgumentException');
         $edge->destroy();
     }
 
@@ -314,15 +317,14 @@ class GraphTest extends AbstractAttributeAwareTest
         $this->assertEquals(array(), $graph->getVertices()->getVector());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRemoveVertexInvalid()
     {
         $graph = new Graph();
         $vertex = $graph->createVertex(1);
 
         $vertex->destroy();
+
+        $this->setExpectedException('InvalidArgumentException');
         $vertex->destroy();
     }
 
@@ -341,9 +343,6 @@ class GraphTest extends AbstractAttributeAwareTest
         $this->assertEdgeEquals($e2, $graphClone->getEdgeCloneInverted($e1));
     }
 
-    /**
-     * @expectedException OverflowException
-     */
     public function testEdgesFailParallel()
     {
         // 1 -> 2, 1 -> 2
@@ -353,13 +352,11 @@ class GraphTest extends AbstractAttributeAwareTest
         $e1 = $v1->createEdgeTo($v2);
         $e2 = $v1->createEdgeTo($v2);
 
+        $this->setExpectedException('OverflowException');
         // which one to return? e1? e2?
         $graph->getEdgeClone($e1);
     }
 
-    /**
-     * @expectedException UnderflowException
-     */
     public function testEdgesFailEdgeless()
     {
         // 1 -> 2
@@ -371,6 +368,7 @@ class GraphTest extends AbstractAttributeAwareTest
 
         $graphCloneEdgeless = $graph->createGraphCloneEdgeless();
 
+        $this->setExpectedException('UnderflowException');
         // nothing to return
         $graphCloneEdgeless->getEdgeClone($e1);
     }

--- a/tests/Set/BaseVerticesTest.php
+++ b/tests/Set/BaseVerticesTest.php
@@ -52,10 +52,10 @@ abstract class BaseVerticesTest extends TestCase
      *
      * @param Vertices $vertices
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveFirst(Vertices $vertices)
     {
+        $this->setExpectedException('UnderflowException');
         $vertices->getVertexFirst();
     }
 
@@ -63,10 +63,10 @@ abstract class BaseVerticesTest extends TestCase
      *
      * @param Vertices $vertices
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveLast(Vertices $vertices)
     {
+        $this->setExpectedException('UnderflowException');
         $vertices->getVertexLast();
     }
 
@@ -74,10 +74,10 @@ abstract class BaseVerticesTest extends TestCase
      *
      * @param Vertices $vertices
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveOrdered(Vertices $vertices)
     {
+        $this->setExpectedException('UnderflowException');
         $vertices->getVertexOrder(Vertices::ORDER_ID);
     }
 
@@ -110,10 +110,10 @@ abstract class BaseVerticesTest extends TestCase
      *
      * @param Vertices $vertices
      * @depends testTwo
-     * @expectedException OutOfBoundsException
      */
     public function testTwoDoesNotContainId3(Vertices $vertices)
     {
+        $this->setExpectedException('OutOfBoundsException');
         $vertices->getVertexId(3);
     }
 
@@ -121,11 +121,12 @@ abstract class BaseVerticesTest extends TestCase
      *
      * @param Vertices $vertices
      * @depends testTwo
-     * @expectedException OutOfBoundsException
      */
     public function testTwoDoesNotContainVertex3(Vertices $vertices)
     {
         $graph = new Graph();
+
+        $this->setExpectedException('OutOfBoundsException');
         $v3 = $graph->createVertex(3);
 
         $vertices->getIndexVertex($v3);

--- a/tests/Set/EdgesTest.php
+++ b/tests/Set/EdgesTest.php
@@ -54,10 +54,10 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveFirst(Edges $edges)
     {
+        $this->setExpectedException('UnderflowException');
         $edges->getEdgeFirst();
     }
 
@@ -65,10 +65,10 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveLast(Edges $edges)
     {
+        $this->setExpectedException('UnderflowException');
         $edges->getEdgeLast();
     }
 
@@ -76,10 +76,10 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testEmpty
-     * @expectedException UnderflowException
      */
     public function testEmptyDoesNotHaveOrdered(Edges $edges)
     {
+        $this->setExpectedException('UnderflowException');
         $edges->getEdgeOrder(Edges::ORDER_WEIGHT);
     }
 
@@ -112,10 +112,10 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testTwo
-     * @expectedException OutOfBoundsException
      */
     public function testTwoDoesNotContainIndex3(Edges $edges)
     {
+        $this->setExpectedException('OutOfBoundsException');
         $edges->getEdgeIndex(3);
     }
 
@@ -123,7 +123,6 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testTwo
-     * @expectedException OutOfBoundsException
      */
     public function testTwoDoesNotContainEdge3(Edges $edges)
     {
@@ -131,6 +130,7 @@ class EdgesTest extends TestCase
         $v3 = $graph->createVertex(3);
         $e3 = $v3->createEdge($v3);
 
+        $this->setExpectedException('OutOfBoundsException');
         $edges->getIndexEdge($e3);
     }
 
@@ -207,10 +207,10 @@ class EdgesTest extends TestCase
      *
      * @param Edges $edges
      * @depends testTwo
-     * @expectedException UnderflowException
      */
     public function testTwoMatchFail(Edges $edges)
     {
+        $this->setExpectedException('UnderflowException');
         $edges->getEdgeMatch(array($this, 'returnFalse'));
     }
 
@@ -224,9 +224,6 @@ class EdgesTest extends TestCase
         return false;
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetEdgeOrderInvalidSortBy()
     {
         // 1 -> 1
@@ -236,16 +233,15 @@ class EdgesTest extends TestCase
 
         $edges = $graph->getEdges();
 
+        $this->setExpectedException('InvalidArgumentException');
         $edges->getEdgeOrder('not a valid callback');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetEdgesOrderInvalidSortBy()
     {
         $edges = $this->createEdges(array());
 
+        $this->setExpectedException('InvalidArgumentException');
         $edges->getEdgesOrder('not a valid callback');
     }
 

--- a/tests/Set/VerticesTest.php
+++ b/tests/Set/VerticesTest.php
@@ -20,9 +20,6 @@ class VerticesTest extends BaseVerticesTest
         $this->assertTrue($vertices->isEmpty());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetVertexOrderInvalidSortBy()
     {
         $graph = new Graph();
@@ -30,16 +27,15 @@ class VerticesTest extends BaseVerticesTest
 
         $vertices = $graph->getVertices();
 
+        $this->setExpectedException('InvalidArgumentException');
         $vertices->getVertexOrder('not a valid callback');
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetVicesOrderInvalidSortBy()
     {
         $vertices = $this->createVertices(array());
 
+        $this->setExpectedException('InvalidArgumentException');
         $vertices->getVerticesOrder('not a valid callback');
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -94,4 +94,21 @@ class TestCase extends BaseTestCase
 
         return $ret;
     }
+
+    public function setExpectedException($exception, $exceptionMessage = '', $exceptionCode = null)
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException($exception);
+            if ($exceptionMessage !== '') {
+                $this->expectExceptionMessage($exceptionMessage);
+            }
+            if ($exceptionCode !== null) {
+                $this->expectExceptionCode($exceptionCode);
+            }
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 5.1
+            parent::setExpectedException($exception, $exceptionMessage, $exceptionCode);
+        }
+    }
 }

--- a/tests/VertexTest.php
+++ b/tests/VertexTest.php
@@ -8,7 +8,10 @@ use Fhaculty\Graph\Vertex;
 
 class VertexTest extends AbstractAttributeAwareTest
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpVertex()
     {
         $this->graph = new Graph();
         $this->vertex = $this->graph->createVertex(1);
@@ -32,11 +35,9 @@ class VertexTest extends AbstractAttributeAwareTest
         $this->assertSame($v2, $this->graph->getVertex(2));
     }
 
-    /**
-     * @expectedException OverflowException
-     */
     public function testCanNotConstructDuplicateVertex()
     {
+        $this->setExpectedException('OverflowException');
         $v2 = new Vertex($this->graph, 1);
     }
 
@@ -107,11 +108,9 @@ class VertexTest extends AbstractAttributeAwareTest
         $this->assertEquals(10, $this->vertex->getBalance());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testBalanceInvalid()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->vertex->setBalance("10");
     }
 
@@ -121,37 +120,28 @@ class VertexTest extends AbstractAttributeAwareTest
         $this->assertEquals(2, $this->vertex->getGroup());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGroupInvalid()
     {
+        $this->setExpectedException('InvalidArgumentException');
         $this->vertex->setGroup("3");
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateEdgeOtherGraphFails()
     {
         $graphOther = new Graph();
 
+        $this->setExpectedException('InvalidArgumentException');
         $this->vertex->createEdge($graphOther->createVertex(2));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testCreateEdgeToOtherGraphFails()
     {
         $graphOther = new Graph();
 
+        $this->setExpectedException('InvalidArgumentException');
         $this->vertex->createEdgeTo($graphOther->createVertex(2));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testRemoveInvalidEdge()
     {
         // 2 -- 3
@@ -159,6 +149,7 @@ class VertexTest extends AbstractAttributeAwareTest
         $v3 = $this->graph->createVertex(3);
         $edge = $v2->createEdge($v3);
 
+        $this->setExpectedException('InvalidArgumentException');
         $this->vertex->removeEdge($edge);
     }
 

--- a/tests/WalkTest.php
+++ b/tests/WalkTest.php
@@ -9,11 +9,9 @@ use Fhaculty\Graph\Walk;
 
 class WalkTest extends TestCase
 {
-    /**
-     * @expectedException UnderflowException
-     */
     public function testWalkCanNotBeEmpty()
     {
+        $this->setExpectedException('UnderflowException');
         Walk::factoryCycleFromVertices(array());
     }
 
@@ -139,9 +137,6 @@ class WalkTest extends TestCase
         $this->assertTrue($walk->isValid());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWalkCycleFromVerticesIncomplete()
     {
         // 1 -- 2 -- 1
@@ -151,13 +146,11 @@ class WalkTest extends TestCase
         $e1 = $v1->createEdge($v2);
         $e2 = $v2->createEdge($v1);
 
+        $this->setExpectedException('InvalidArgumentException');
         // should actually be [v1, v2, v1]
         Walk::factoryCycleFromVertices(array($v1, $v2));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWalkCycleInvalid()
     {
         // 1 -- 2
@@ -166,6 +159,7 @@ class WalkTest extends TestCase
         $v2 = $graph->createVertex(2);
         $e1 = $v1->createEdge($v2);
 
+        $this->setExpectedException('InvalidArgumentException');
         Walk::factoryCycleFromEdges(array($e1), $v1);
     }
 
@@ -200,22 +194,20 @@ class WalkTest extends TestCase
      *
      * @param Vertex $v1
      * @depends testLoopCycle
-     * @expectedException InvalidArgumentException
      */
     public function testFactoryCycleFromVerticesIncomplete(Vertex $v1)
     {
+        $this->setExpectedException('InvalidArgumentException');
         // should actually be [v1, v1]
         Walk::factoryCycleFromVertices(array($v1));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidPredecessors()
     {
         $graph = new Graph();
         $v1 = $graph->createVertex(1);
 
+        $this->setExpectedException('InvalidArgumentException');
         Walk::factoryCycleFromPredecessorMap(array(), $v1);
     }
 


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

It's also possible to run this code with PHP 8 🎉
```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.4.4 by Sebastian Bergmann and contributors.

...............................................................  63 / 176 ( 35%)
............................................................... 126 / 176 ( 71%)
..................................................              176 / 176 (100%)

Time: 00:00.023, Memory: 8.00 MB

OK (176 tests, 446 assertions)
```