### PR TITLE
Support PHP 8.1 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         php:
+          - 8.1
           - 8.0
           - 7.4
           - 7.3

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 This project aims to run on any platform and thus does not require any PHP
 extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
 HHVM.
-It's *highly recommended to use PHP 7+* for this project.
+It's *highly recommended to use the latest supported PHP version* for this project.
 
 You may also want to install some of the [additional components](#components).
 A list of all official components can be found in the [graphp project](https://github.com/graphp).

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,9 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         cacheResult="false"
          colors="true"
-         cacheResult="false">
+         convertDeprecationsToExceptions="true">
     <testsuites>
         <testsuite name="Graph test suite">
             <directory>./tests/</directory>

--- a/src/Set/Edges.php
+++ b/src/Set/Edges.php
@@ -383,6 +383,7 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
      * @return int
      * @see self::isEmpty()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->edges);
@@ -409,6 +410,7 @@ class Edges implements \Countable, \IteratorAggregate, EdgesAggregate
      *
      * @return \IteratorIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \IteratorIterator(new \ArrayIterator($this->edges));

--- a/src/Set/Vertices.php
+++ b/src/Set/Vertices.php
@@ -411,6 +411,7 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
      * @return int
      * @see self::isEmpty()
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->vertices);
@@ -448,6 +449,7 @@ class Vertices implements \Countable, \IteratorAggregate, VerticesAggregate
      *
      * @return \IteratorIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new \IteratorIterator(new \ArrayIterator($this->vertices));


### PR DESCRIPTION
For the reference: This only applies to v0.9.x release branch, so I've just updated the CI setup with #207. In the upcoming v1 release branch, the `Set` classes have been removed entirely via #195.

Builds on top of #207