### PR TITLE
Drop legacy HHVM support due to lack of support and failing test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,14 +31,3 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
-
-  PHPUnit-hhvm:
-    name: PHPUnit (HHVM)
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: azjezz/setup-hhvm@v1
-        with:
-          version: lts-3.30
-      - run: hhvm $(which composer) install
-      - run: hhvm vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -119,8 +119,7 @@ $ composer require clue/graph:^0.9.3
 See also the [CHANGELOG](CHANGELOG.md) for details about version upgrades.
 
 This project aims to run on any platform and thus does not require any PHP
-extensions and supports running on legacy PHP 5.3 through current PHP 8+ and
-HHVM.
+extensions and supports running on legacy PHP 5.3 through current PHP 8+.
 It's *highly recommended to use the latest supported PHP version* for this project.
 
 You may also want to install some of the [additional components](#components).


### PR DESCRIPTION
HHVM does not support PHP anymore and regularly causes our builds to fail, so no reason to keep legacy HHVM support around anymore.

Builds on top of #202, #162 and others
Refs https://github.com/clue/phar-composer/pull/127